### PR TITLE
feat: support format tool error recovery and error indent/dedent code format

### DIFF
--- a/kclvm/api/src/service/service_impl.rs
+++ b/kclvm/api/src/service/service_impl.rs
@@ -278,7 +278,15 @@ impl KclvmServiceImpl {
     /// assert_eq!(result.formatted, source.as_bytes().to_vec());
     /// ```
     pub fn format_code(&self, args: &FormatCodeArgs) -> anyhow::Result<FormatCodeResult> {
-        let (formatted, _) = format_source("", &args.source)?;
+        let (formatted, _) = format_source(
+            "",
+            &args.source,
+            &FormatOptions {
+                is_stdout: false,
+                recursively: false,
+                omit_errors: true,
+            },
+        )?;
         Ok(FormatCodeResult {
             formatted: formatted.as_bytes().to_vec(),
         })
@@ -313,6 +321,7 @@ impl KclvmServiceImpl {
             &FormatOptions {
                 recursively,
                 is_stdout: false,
+                omit_errors: true,
             },
         )?;
         Ok(FormatPathResult { changed_paths })

--- a/kclvm/ast/src/token.rs
+++ b/kclvm/ast/src/token.rs
@@ -340,6 +340,12 @@ impl Token {
             _ => false,
         }
     }
+
+    /// Whether the token kind is in the recovery token set, when meets errors, drop it.
+    #[inline]
+    pub fn is_in_recovery_set(&self) -> bool {
+        matches!(self.kind, TokenKind::Indent | TokenKind::Dummy)
+    }
 }
 
 impl PartialEq<TokenKind> for Token {

--- a/kclvm/cmd/src/fmt.rs
+++ b/kclvm/cmd/src/fmt.rs
@@ -13,6 +13,7 @@ pub fn fmt_command(matches: &ArgMatches) -> Result<()> {
                 &FormatOptions {
                     is_stdout: bool_from_matches(matches, "std_output").unwrap_or_default(),
                     recursively: bool_from_matches(matches, "recursive").unwrap_or_default(),
+                    omit_errors: true,
                 },
             )?;
             Ok(())

--- a/kclvm/parser/src/lexer/indent.rs
+++ b/kclvm/parser/src/lexer/indent.rs
@@ -92,6 +92,7 @@ impl<'a> Lexer<'a> {
                     }
                     Ordering::Less => {
                         let mut dedents = Vec::new();
+                        let mut indents = Vec::new();
 
                         loop {
                             match ordering {
@@ -99,7 +100,9 @@ impl<'a> Lexer<'a> {
                                     match order {
                                         Ordering::Less => {
                                             // Pop indents util we find an equal ident level
-                                            self.indent_cxt.indents.pop();
+                                            if let Some(indent) = self.indent_cxt.indents.pop() {
+                                                indents.push(indent);
+                                            }
                                             // update pos & collect dedent
                                             // For dedent token, we ignore the length
                                             let dedent = Token::new(
@@ -113,6 +116,10 @@ impl<'a> Lexer<'a> {
                                             break;
                                         }
                                         Ordering::Greater => {
+                                            if let Some(indent) = indents.pop() {
+                                                self.indent_cxt.indents.push(indent);
+                                            }
+                                            dedents.pop();
                                             self.sess.struct_span_error(
                                             &format!("unindent {} does not match any outer indentation level", indent.spaces),
                                             self.span(self.pos, self.pos),

--- a/kclvm/parser/src/parser/expr.rs
+++ b/kclvm/parser/src/parser/expr.rs
@@ -49,6 +49,12 @@ impl<'a> Parser<'a> {
     /// Syntax:
     /// test: if_expr | simple_expr
     pub(crate) fn parse_expr(&mut self) -> NodeRef<Expr> {
+        if self.token.is_in_recovery_set() {
+            self.sess
+                .struct_span_error("expected expression", self.token.span);
+            self.bump();
+        }
+
         let token = self.token;
         let operand = self.parse_simple_expr();
 
@@ -912,13 +918,6 @@ impl<'a> Parser<'a> {
                 // If we don't find the indentation, skip and parse the next statement.
                 self.sess
                     .struct_token_error(&[TokenKind::Indent.into()], self.token);
-                return Box::new(Node::node(
-                    Expr::List(ListExpr {
-                        elts: vec![],
-                        ctx: ExprContext::Load,
-                    }),
-                    self.sess.struct_token_loc(token, self.token),
-                ));
             }
             true
         } else {
@@ -1256,10 +1255,6 @@ impl<'a> Parser<'a> {
                 // If we don't find the indentation, skip and parse the next statement.
                 self.sess
                     .struct_token_error(&[TokenKind::Indent.into()], self.token);
-                return Box::new(Node::node(
-                    Expr::Config(ConfigExpr { items: vec![] }),
-                    self.sess.struct_token_loc(token, self.token),
-                ));
             }
             true
         } else {


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

feat: support format tool error recovery and error indent/dedent code format.

+ By supporting the `omit_errors` option to impl the code formatting feature with syntax errors
+ Optimize KCL indentation error handling and recovery, so that configuration code with indentation errors can still be formatted correctly.
+ Fix unexpected `ConfigExpr` and `ListExpr` parser error handling.

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->

+ kclvm/cmd/src/fmt.rs
+ kclvm/parser/src/lexer/indent.rs
+ kclvm/parser/src/lib.rs
+ kclvm/parser/src/parser/expr.rs

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

+ `test_format_with_omit_error_option` at `kclvm/tools/src/format/tests.rs`

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
