### PR TITLE
feat: enhance config attribute type inference through the config attribute type map.

### DIFF
--- a/kclvm/api/src/service/ty.rs
+++ b/kclvm/api/src/service/ty.rs
@@ -1,7 +1,7 @@
 use crate::gpyrpc::{Decorator, KclType};
 use indexmap::IndexSet;
 use kclvm_runtime::SCHEMA_SETTINGS_ATTR_NAME;
-use kclvm_sema::ty::{SchemaType, Type};
+use kclvm_sema::ty::{DictType, SchemaType, Type};
 use std::collections::HashMap;
 
 /// Convert the kcl sematic type to the kcl protobuf type.
@@ -12,7 +12,7 @@ pub(crate) fn kcl_ty_to_pb_ty(ty: &Type) -> KclType {
             item: Some(Box::new(kcl_ty_to_pb_ty(item_ty))),
             ..Default::default()
         },
-        kclvm_sema::ty::TypeKind::Dict(key_ty, val_ty) => KclType {
+        kclvm_sema::ty::TypeKind::Dict(DictType { key_ty, val_ty, .. }) => KclType {
             r#type: "dict".to_string(),
             key: Some(Box::new(kcl_ty_to_pb_ty(key_ty))),
             item: Some(Box::new(kcl_ty_to_pb_ty(val_ty))),

--- a/kclvm/sema/src/resolver/attr.rs
+++ b/kclvm/sema/src/resolver/attr.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use crate::builtin::system_module::{get_system_module_members, UNITS, UNITS_NUMBER_MULTIPLIER};
 use crate::builtin::STRING_MEMBER_FUNCTIONS;
 use crate::resolver::Resolver;
-use crate::ty::{ModuleKind, Type, TypeKind};
+use crate::ty::{DictType, ModuleKind, Type, TypeKind};
 use kclvm_error::diagnostic::Range;
 use kclvm_error::*;
 
@@ -46,7 +46,17 @@ impl<'ctx> Resolver<'ctx> {
                 Some(ty) => (true, Rc::new(ty.clone())),
                 None => (false, self.any_ty()),
             },
-            TypeKind::Dict(_, val_ty) => (true, Rc::new(val_ty.as_ref().clone())),
+            TypeKind::Dict(DictType {
+                key_ty: _,
+                val_ty,
+                attrs,
+            }) => (
+                true,
+                attrs
+                    .get(attr)
+                    .map(|attr| attr.ty.clone())
+                    .unwrap_or(Rc::new(val_ty.as_ref().clone())),
+            ),
             // union type load attr based the type guard. e.g, a: str|int; if a is str: xxx; if a is int: xxx;
             // return sup([self.load_attr_type(t, attr, filename, line, column) for t in obj.types])
             TypeKind::Union(_) => (true, self.any_ty()),

--- a/kclvm/sema/src/resolver/loop.rs
+++ b/kclvm/sema/src/resolver/loop.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use crate::resolver::Resolver;
-use crate::ty::{sup, Type, TypeKind};
+use crate::ty::{sup, DictType, Type, TypeKind};
 use kclvm_ast::ast;
 use kclvm_ast::pos::GetPos;
 use kclvm_error::diagnostic::Range;
@@ -53,7 +53,7 @@ impl<'ctx> Resolver<'ctx> {
                         );
                     }
                 }
-                TypeKind::Dict(key_ty, val_ty) => {
+                TypeKind::Dict(DictType { key_ty, val_ty, .. }) => {
                     first_var_ty = sup(&[key_ty.clone(), first_var_ty.clone()]);
                     self.set_type_to_scope(
                         first_var_name.as_ref().unwrap(),

--- a/kclvm/sema/src/ty/constructor.rs
+++ b/kclvm/sema/src/ty/constructor.rs
@@ -33,7 +33,11 @@ impl Type {
     #[inline]
     pub fn dict(key_ty: Rc<Type>, val_ty: Rc<Type>) -> Type {
         Type {
-            kind: TypeKind::Dict(key_ty, val_ty),
+            kind: TypeKind::Dict(DictType {
+                key_ty,
+                val_ty,
+                attrs: IndexMap::new(),
+            }),
             flags: TypeFlags::DICT,
             is_type_alias: false,
         }
@@ -42,6 +46,32 @@ impl Type {
     #[inline]
     pub fn dict_ref(key_ty: Rc<Type>, val_ty: Rc<Type>) -> Rc<Type> {
         Rc::new(Self::dict(key_ty, val_ty))
+    }
+    /// Construct a dict type with attrs
+    #[inline]
+    pub fn dict_with_attrs(
+        key_ty: TypeRef,
+        val_ty: TypeRef,
+        attrs: IndexMap<String, Attr>,
+    ) -> Type {
+        Type {
+            kind: TypeKind::Dict(DictType {
+                key_ty,
+                val_ty,
+                attrs,
+            }),
+            flags: TypeFlags::DICT,
+            is_type_alias: false,
+        }
+    }
+    /// Construct a dict type reference with attrs
+    #[inline]
+    pub fn dict_ref_with_attrs(
+        key_ty: TypeRef,
+        val_ty: TypeRef,
+        attrs: IndexMap<String, Attr>,
+    ) -> TypeRef {
+        Rc::new(Self::dict_with_attrs(key_ty, val_ty, attrs))
     }
     /// Construct a bool literal type.
     #[inline]
@@ -310,7 +340,7 @@ impl Type {
             | TypeKind::Str
             | TypeKind::StrLit(_)
             | TypeKind::List(_)
-            | TypeKind::Dict(_, _)
+            | TypeKind::Dict(DictType { .. })
             | TypeKind::Union(_)
             | TypeKind::Schema(_)
             | TypeKind::NumberMultiplier(_)

--- a/kclvm/sema/src/ty/into.rs
+++ b/kclvm/sema/src/ty/into.rs
@@ -13,7 +13,7 @@ impl Type {
     #[inline]
     pub fn dict_entry_ty(&self) -> (Rc<Type>, Rc<Type>) {
         match &self.kind {
-            TypeKind::Dict(key_ty, val_ty) => (key_ty.clone(), val_ty.clone()),
+            TypeKind::Dict(DictType { key_ty, val_ty, .. }) => (key_ty.clone(), val_ty.clone()),
             _ => bug!("invalid dict type {}", self.ty_str()),
         }
     }
@@ -21,7 +21,7 @@ impl Type {
     #[inline]
     pub fn config_key_ty(&self) -> Rc<Type> {
         match &self.kind {
-            TypeKind::Dict(key_ty, _) => key_ty.clone(),
+            TypeKind::Dict(DictType { key_ty, .. }) => key_ty.clone(),
             TypeKind::Schema(schema_ty) => schema_ty.key_ty(),
             _ => bug!("invalid config type {}", self.ty_str()),
         }
@@ -30,7 +30,9 @@ impl Type {
     #[inline]
     pub fn config_val_ty(&self) -> Rc<Type> {
         match &self.kind {
-            TypeKind::Dict(_, val_ty) => val_ty.clone(),
+            TypeKind::Dict(DictType {
+                key_ty: _, val_ty, ..
+            }) => val_ty.clone(),
             TypeKind::Schema(schema_ty) => schema_ty.val_ty(),
             _ => bug!("invalid config type {}", self.ty_str()),
         }
@@ -79,7 +81,7 @@ impl Type {
             }
             TypeKind::StrLit(v) => format!("\"{}\"", v.replace('"', "\\\"")),
             TypeKind::List(item_ty) => format!("[{}]", item_ty.into_type_annotation_str()),
-            TypeKind::Dict(key_ty, val_ty) => {
+            TypeKind::Dict(DictType { key_ty, val_ty, .. }) => {
                 format!(
                     "{{{}:{}}}",
                     key_ty.into_type_annotation_str(),

--- a/kclvm/sema/src/ty/walker.rs
+++ b/kclvm/sema/src/ty/walker.rs
@@ -1,15 +1,31 @@
 use std::rc::Rc;
 
-use super::Type;
+use super::{Attr, DictType, Type};
 
 /// Walk one type recursively and deal the type using the `walk_fn`
 pub fn walk_type(ty: &Type, walk_fn: impl Fn(&Type) -> Rc<Type> + Copy) -> Rc<Type> {
     let ty = walk_fn(ty);
     match &ty.kind {
         super::TypeKind::List(item_ty) => Rc::new(Type::list(walk_type(item_ty, walk_fn))),
-        super::TypeKind::Dict(key_ty, val_ty) => Rc::new(Type::dict(
+        super::TypeKind::Dict(DictType {
+            key_ty,
+            val_ty,
+            attrs,
+        }) => Rc::new(Type::dict_with_attrs(
             walk_type(key_ty, walk_fn),
             walk_type(val_ty, walk_fn),
+            attrs
+                .into_iter()
+                .map(|(key, attr)| {
+                    (
+                        key.to_string(),
+                        Attr {
+                            ty: walk_type(&attr.ty, walk_fn),
+                            range: attr.range.clone(),
+                        },
+                    )
+                })
+                .collect(),
         )),
         super::TypeKind::Union(types) => Rc::new(Type::union(
             &types

--- a/kclvm/tools/src/LSP/src/goto_def.rs
+++ b/kclvm/tools/src/LSP/src/goto_def.rs
@@ -15,7 +15,7 @@ use kclvm_compiler::pkgpath_without_prefix;
 use kclvm_error::Position as KCLPos;
 
 use kclvm_sema::resolver::scope::{ProgramScope, Scope, ScopeObject};
-use kclvm_sema::ty::SchemaType;
+use kclvm_sema::ty::{DictType, SchemaType};
 use lsp_types::{GotoDefinitionResponse, Url};
 use lsp_types::{Location, Range};
 use std::cell::RefCell;
@@ -217,7 +217,7 @@ pub(crate) fn resolve_var(
                                 None => None,
                             }
                         }
-                        kclvm_sema::ty::TypeKind::Dict(_, _) => {
+                        kclvm_sema::ty::TypeKind::Dict(DictType { attrs: _, .. }) => {
                             // Todo: find key def in dict
                             None
                         }

--- a/test/grammar/types/union_ty/union_ty_11/main.k
+++ b/test/grammar/types/union_ty/union_ty_11/main.k
@@ -1,0 +1,6 @@
+metadata = {
+    name = "app"
+    labels.app = "app"
+}
+labels: {str:str} = metadata.labels
+

--- a/test/grammar/types/union_ty/union_ty_11/stdout.golden
+++ b/test/grammar/types/union_ty/union_ty_11/stdout.golden
@@ -1,0 +1,6 @@
+metadata:
+  name: app
+  labels:
+    app: app
+labels:
+  app: app

--- a/test/grammar/types/union_ty/union_ty_12/main.k
+++ b/test/grammar/types/union_ty/union_ty_12/main.k
@@ -1,0 +1,6 @@
+metadata = {
+    name = "app"
+    labels.app = "app"
+}
+labels: {str:str} = {**metadata.labels}
+

--- a/test/grammar/types/union_ty/union_ty_12/stdout.golden
+++ b/test/grammar/types/union_ty/union_ty_12/stdout.golden
@@ -1,0 +1,6 @@
+metadata:
+  name: app
+  labels:
+    app: app
+labels:
+  app: app


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

re #635 

feat: enhance config attribute type inference through the config attribute type map.

```python
metadata = {
    name = "app"
    labels.app = "app"
}
labels: {str:str} = metadata.labels
```

Before this PR, the type of `metadata.labels` will be inferred as a `{str:str}|str` type. In fact, we can derive more precise types, and this PR solves this problem. The more information is in #635 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->

The kcl sematic model crate

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [x] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

+ test/grammar/types/union_ty/union_ty_11/main.k
+ test/grammar/types/union_ty/union_ty_12/main.k

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
