### PR TITLE
feat: async build word index map when init lsp state

### DIFF
--- a/kclvm/tools/src/LSP/src/state.rs
+++ b/kclvm/tools/src/LSP/src/state.rs
@@ -107,24 +107,7 @@ impl LanguageServerState {
             Handle { handle, _receiver }
         };
 
-        // build word index for all the workspace folders
-        // todo: async
-        let mut word_index_map = HashMap::new();
-        if let Some(workspace_folders) = initialize_params.workspace_folders {
-            for folder in workspace_folders {
-                let path = folder.uri.path();
-                if let Ok(word_index) = build_word_index(path.to_string()) {
-                    word_index_map.insert(folder.uri, word_index);
-                }
-            }
-        } else if let Some(root_uri) = initialize_params.root_uri {
-            let path = root_uri.path();
-            if let Ok(word_index) = build_word_index(path.to_string()) {
-                word_index_map.insert(root_uri, word_index);
-            }
-        }
-
-        LanguageServerState {
+        let state = LanguageServerState {
             sender,
             request_queue: ReqQueue::default(),
             _config: config,
@@ -135,9 +118,16 @@ impl LanguageServerState {
             shutdown_requested: false,
             analysis: Analysis::default(),
             opened_files: IndexSet::new(),
-            word_index_map: Arc::new(RwLock::new(word_index_map)),
+            word_index_map: Arc::new(RwLock::new(HashMap::new())),
             loader,
-        }
+        };
+
+        let word_index_map = state.word_index_map.clone();
+        state
+            .thread_pool
+            .execute(move || build_word_index_map(word_index_map, initialize_params));
+
+        state
     }
 
     /// Blocks until a new event is received from one of the many channels the language server
@@ -332,4 +322,23 @@ pub(crate) fn log_message(message: String, sender: &Sender<Task>) -> anyhow::Res
         lsp_types::LogMessageParams { typ, message },
     )))?;
     Ok(())
+}
+
+fn build_word_index_map(
+    word_index_map: Arc<RwLock<HashMap<Url, HashMap<String, Vec<Location>>>>>,
+    initialize_params: InitializeParams,
+) {
+    if let Some(workspace_folders) = initialize_params.workspace_folders {
+        for folder in workspace_folders {
+            let path = folder.uri.path();
+            if let Ok(word_index) = build_word_index(path.to_string()) {
+                word_index_map.write().insert(folder.uri, word_index);
+            }
+        }
+    } else if let Some(root_uri) = initialize_params.root_uri {
+        let path = root_uri.path();
+        if let Ok(word_index) = build_word_index(path.to_string()) {
+            word_index_map.write().insert(root_uri, word_index);
+        }
+    }
 }

--- a/kclvm/tools/src/LSP/src/tests.rs
+++ b/kclvm/tools/src/LSP/src/tests.rs
@@ -40,6 +40,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
 
 use kclvm_ast::ast::Program;
@@ -1611,6 +1612,8 @@ fn rename_test() {
             },
         },
     );
+    // Wait fro async build word_index_map
+    thread::sleep(Duration::from_secs(1));
 
     let id = server.next_request_id.get();
     server.next_request_id.set(id.wrapping_add(1));


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):
lsp/state.rs
<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):
async build word index map when init lsp state， Konfig startup time reduced to 1/3 (27s -> 9s). There may still be some read-write locks
<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:
Konfig startup time reduced to 1/3 (27s -> 9s).  
<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
