### PR TITLE
fix: use Arc in sema benchmark

### DIFF
--- a/kclvm/sema/benches/my_benchmark.rs
+++ b/kclvm/sema/benches/my_benchmark.rs
@@ -1,19 +1,19 @@
-use std::rc::Rc;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 use kclvm_sema::ty::*;
+
+use std::sync::Arc;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("sup", |b| {
         b.iter(|| {
             let types = vec![
-                Rc::new(Type::int_lit(1)),
-                Rc::new(Type::INT),
-                Rc::new(Type::union(&[
-                    Rc::new(Type::STR),
-                    Rc::new(Type::dict(Rc::new(Type::STR), Rc::new(Type::STR))),
+                Arc::new(Type::int_lit(1)),
+                Arc::new(Type::INT),
+                Arc::new(Type::union(&[
+                    Arc::new(Type::STR),
+                    Arc::new(Type::dict(Arc::new(Type::STR), Arc::new(Type::STR))),
                 ])),
-                Rc::new(Type::dict(Rc::new(Type::ANY), Rc::new(Type::ANY))),
+                Arc::new(Type::dict(Arc::new(Type::ANY), Arc::new(Type::ANY))),
             ];
             sup(&types);
         })


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

fix #836

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

fix benchmark for sema

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [x] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

```
......
test result: ok. 0 passed; 0 failed; 38 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/my_benchmark.rs (/workspaces/kcl/kclvm/target/release/deps/my_benchmark-26942d85c4160f9c)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
sup                     time:   [1.3954 µs 1.3963 µs 1.3973 µs]                 
                        change: [-0.5804% -0.4520% -0.3373%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```