### PR TITLE
refactor(config): fix warnings by 'cargo clippy' for config

### DIFF
--- a/kclvm/config/src/cache.rs
+++ b/kclvm/config/src/cache.rs
@@ -135,7 +135,7 @@ where
     create_dir_all(&cache_dir).unwrap();
     let tmp_filename = temp_file(&cache_dir, pkgpath);
     save_data_to_file(&dst_filename, &tmp_filename, data);
-    return Ok(());
+    Ok(())
 }
 
 #[inline]

--- a/kclvm/config/src/modfile.rs
+++ b/kclvm/config/src/modfile.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_KPM_SUBDIR: &str = "kpm";
 pub fn get_vendor_home() -> String {
     match env::var(KCL_PKG_PATH) {
         Ok(path) => path,
-        Err(_) => create_default_vendor_home().unwrap_or(String::default()),
+        Err(_) => create_default_vendor_home().unwrap_or_default(),
     }
 }
 
@@ -106,7 +106,7 @@ pub fn get_pkg_root_from_paths(file_paths: &[String], workdir: String) -> Result
         return Ok("".to_string());
     }
     if m.len() == 1 {
-        return Ok(last_root);
+        Ok(last_root)
     } else if !workdir.is_empty() {
         return Ok(workdir);
     } else {

--- a/kclvm/config/src/path.rs
+++ b/kclvm/config/src/path.rs
@@ -72,7 +72,7 @@ impl ModRelativePath {
     /// ```
     pub fn is_relative_path(&self) -> Result<bool> {
         Ok(Regex::new(RELATIVE_PATH_PREFFIX)?
-            .find(&self.path.as_bytes())?
+            .find(self.path.as_bytes())?
             .map_or(false, |mat| mat.start() == 0))
     }
 
@@ -97,7 +97,7 @@ impl ModRelativePath {
         }
 
         Ok(Regex::new(RELATIVE_PATH_PREFFIX)?
-            .captures(&self.path.as_bytes())?
+            .captures(self.path.as_bytes())?
             .and_then(|caps| caps.name(ROOT_PKG_NAME_FLAG))
             .map(|mat| std::str::from_utf8(mat.as_bytes()).map(|s| s.to_string()))
             .transpose()?)
@@ -124,7 +124,7 @@ impl ModRelativePath {
         }
 
         Ok(Regex::new(RELATIVE_PATH_PREFFIX)?
-            .captures(&self.path.as_bytes())?
+            .captures(self.path.as_bytes())?
             .map_or_else(
                 || self.get_path(),
                 |caps| {
@@ -136,11 +136,11 @@ impl ModRelativePath {
                         "",
                     );
                     let res = PathBuf::from(root_path)
-                        .join(sub_path.to_string())
+                        .join(sub_path)
                         .display()
                         .to_string();
 
-                    return res;
+                    res
                 },
             ))
     }
@@ -153,19 +153,19 @@ mod test_relative_path {
     #[test]
     fn test_is_relative_path() {
         let path = ModRelativePath::new("${name:KCL_MOD}/src/path.rs".to_string());
-        assert_eq!(path.is_relative_path().unwrap(), true);
+        assert!(path.is_relative_path().unwrap());
         let path = ModRelativePath::new("${KCL_MOD}/src/path.rs".to_string());
-        assert_eq!(path.is_relative_path().unwrap(), true);
+        assert!(path.is_relative_path().unwrap());
         let path = ModRelativePath::new("/usr/${name:KCL_MOD}/src/path.rs".to_string());
-        assert_eq!(path.is_relative_path().unwrap(), false);
+        assert!(!path.is_relative_path().unwrap());
         let path = ModRelativePath::new("/src/path.rs".to_string());
-        assert_eq!(path.is_relative_path().unwrap(), false);
+        assert!(!path.is_relative_path().unwrap());
         let path = ModRelativePath::new("./src/path.rs".to_string());
-        assert_eq!(path.is_relative_path().unwrap(), false);
+        assert!(!path.is_relative_path().unwrap());
         let path = ModRelativePath::new("${K_MOD}/src/path.rs".to_string());
-        assert_eq!(path.is_relative_path().unwrap(), false);
+        assert!(!path.is_relative_path().unwrap());
         let path = ModRelativePath::new("${:KCL_MOD}/src/path.rs".to_string());
-        assert_eq!(path.is_relative_path().unwrap(), false);
+        assert!(!path.is_relative_path().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->
issue #191 
#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->
KCLVM/config

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

Before:
```
abhi_ubuntu@MADHUSANJ:~/kcl1/kcl/kclvm/driver$ cargo clippy --fix --allow-dirty
    Checking kclvm-driver v0.7.4 (/home/abhi_ubuntu/kcl1/kcl/kclvm/driver)
warning: unnecessary `if let` since only the `Ok` variant of the iterator element is used
  --> driver/src/lib.rs:31:5
   |
31 |       for path in paths {
   |       ^           ----- help: try: `paths.flatten()`
   |  _____|
   | |
32 | |         if let Ok(path) = path {
33 | |             matched_files.push(path.to_string_lossy().to_string());
34 | |         }
35 | |     }
   | |_____^
   |
help: ...and remove the `if let` statement in the for loop
  --> driver/src/lib.rs:32:9
   |
32 | /         if let Ok(path) = path {
33 | |             matched_files.push(path.to_string_lossy().to_string());
34 | |         }
   | |_________^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_flatten
   = note: `#[warn(clippy::manual_flatten)]` on by default

warning: you seem to use `.enumerate()` and immediately discard the index
  --> driver/src/lib.rs:64:22
   |
64 |     for (_, file) in k_files.iter().enumerate() {
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_enumerate_index
   = note: `#[warn(clippy::unused_enumerate_index)]` on by default
help: remove the `.enumerate()` call
   |
64 |     for file in k_files.iter() {
   |         ~~~~    ~~~~~~~~~~~~~~

warning: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
   --> driver/src/lib.rs:207:29
    |
207 | pub fn lookup_kcl_yaml(dir: &PathBuf) -> io::Result<PathBuf> {
    |                             ^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
    = note: `#[warn(clippy::ptr_arg)]` on by default
help: change this to
    |
207 ~ pub fn lookup_kcl_yaml(dir: &Path) -> io::Result<PathBuf> {
208 ~     let mut path = dir.to_path_buf();
    |

warning: `kclvm-driver` (lib) generated 3 warnings
warning: `assert_eq` of unit values detected. This will always succeed
  --> driver/src/tests.rs:79:5
   |
79 | /     assert_eq!(
80 | |         expand_input_files(&input_files).sort(),
81 | |         expected_files.sort()
82 | |     );
   | |_____^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unit_cmp
   = note: `#[warn(clippy::unit_cmp)]` on by default

warning: `assert_eq` of unit values detected. This will always succeed
   --> driver/src/tests.rs:115:5
    |
115 | /     assert_eq!(
116 | |         expand_input_files(&input_files).sort(),
117 | |         expected_files.sort()
118 | |     );
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unit_cmp

warning: `kclvm-driver` (lib test) generated 5 warnings (3 duplicates)
    Finished dev [unoptimized + debuginfo] target(s) in 1.74s
warning: the following packages contain code that will be rejected by a future version of Rust: rustc-serialize v0.3.24
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
abhi_ubuntu@MADHUSANJ:~/kcl1/kcl/kclvm/driver$ cd .
abhi_ubuntu@MADHUSANJ:~/kcl1/kcl/kclvm/driver$ cd ..
abhi_ubuntu@MADHUSANJ:~/kcl1/kcl/kclvm$ cd config
abhi_ubuntu@MADHUSANJ:~/kcl1/kcl/kclvm/config$ cargo clippy --fix --allow-dirty
    Checking rustc_data_structures v0.0.1
    Checking kclvm-runtime v0.7.4 (/home/abhi_ubuntu/kcl1/kcl/kclvm/runtime)
   Compiling kclvm-version v0.7.4 (/home/abhi_ubuntu/kcl1/kcl/kclvm/version)
    Checking rustc_span v0.0.1
    Checking compiler_base_span v0.0.1
    Checking compiler_base_span v0.0.2 (/home/abhi_ubuntu/kcl1/kcl/compiler_base/span)
    Checking compiler_base_error v0.0.10
    Checking kclvm-span v0.7.4 (/home/abhi_ubuntu/kcl1/kcl/kclvm/span)
    Checking compiler_base_session v0.0.13 (/home/abhi_ubuntu/kcl1/kcl/compiler_base/session)
    Checking kclvm-error v0.7.4 (/home/abhi_ubuntu/kcl1/kcl/kclvm/error)
    Checking kclvm-ast v0.7.4 (/home/abhi_ubuntu/kcl1/kcl/kclvm/ast)
    Checking kclvm-config v0.7.4 (/home/abhi_ubuntu/kcl1/kcl/kclvm/config)
       Fixed config/src/modfile.rs (2 fixes)
       Fixed config/src/path.rs (5 fixes)
       Fixed config/src/cache.rs (1 fix)
warning: the borrowed expression implements the required traits
   --> config/src/path.rs:139:31
    |
139 |                         .join(&sub_path)
    |                               ^^^^^^^^^ help: change this to: `sub_path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
    = note: `#[warn(clippy::needless_borrows_for_generic_args)]` on by default

warning: `kclvm-config` (lib) generated 1 warning (run `cargo clippy --fix --lib -p kclvm-config` to apply 1 suggestion)
       Fixed config/src/settings.rs (1 fix)
       Fixed config/src/path.rs (8 fixes)
    Finished dev [unoptimized + debuginfo] target(s) in 7.42s
warning: the following packages contain code that will be rejected by a future version of Rust: rustc-serialize v0.3.24
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
abhi_ubuntu@MADHUSANJ:~/kcl1/kcl/kclvm/config$ cargo clippy --fix --allow-dirty
    Checking kclvm-config v0.7.4 (/home/abhi_ubuntu/kcl1/kcl/kclvm/config)
       Fixed config/src/cache.rs (1 fix)
       Fixed config/src/path.rs (5 fixes)
       Fixed config/src/modfile.rs (2 fixes)
warning: the borrowed expression implements the required traits
   --> config/src/path.rs:139:31
    |
139 |                         .join(&sub_path)
    |                               ^^^^^^^^^ help: change this to: `sub_path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
    = note: `#[warn(clippy::needless_borrows_for_generic_args)]` on by default

       Fixed config/src/settings.rs (1 fix)
       Fixed config/src/path.rs (8 fixes)
warning: `kclvm-config` (lib) generated 1 warning (run `cargo clippy --fix --lib -p kclvm-config` to apply 1 suggestion)
    Finished dev [unoptimized + debuginfo] target(s) in 2.17s
warning: the following packages contain code that will be rejected by a future version of Rust: rustc-serialize v0.3.24
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```
After:
```
abhi_ubuntu@MADHUSANJ:~/kcl1/kcl/kclvm/config$ cargo clippy --fix --allow-dirty
    Checking kclvm-config v0.7.4 (/home/abhi_ubuntu/kcl1/kcl/kclvm/config)
    Finished dev [unoptimized + debuginfo] target(s) in 2.37s
warning: the following packages contain code that will be rejected by a future version of Rust: rustc-serialize v0.3.24
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`

```