### PR TITLE
fix: formatting support for multiple if statements

### DIFF
--- a/kclvm/ast_pretty/src/node.rs
+++ b/kclvm/ast_pretty/src/node.rs
@@ -122,22 +122,18 @@ impl<'p, 'ctx> MutSelfTypedResultWalker<'ctx> for Printer<'p> {
         self.stmts(&if_stmt.body);
         self.write_indentation(Indentation::Dedent);
         if !if_stmt.orelse.is_empty() {
-            if let ast::Stmt::If(elif_stmt) = &if_stmt.orelse[0].node {
-                // Nested if statements need to be considered,
-                // so `el` needs to be preceded by the current indentation.
-                self.fill("el");
-                self.walk_if_stmt(elif_stmt);
-            } else {
-                // Nested if statements need to be considered,
-                // so `el` needs to be preceded by the current indentation.
-                self.fill("else:");
-                self.write_newline_without_fill();
-                self.write_indentation(Indentation::Indent);
-                self.stmts(&if_stmt.orelse);
-                self.write_indentation(Indentation::Dedent);
+            for (_, sub_stmt) in if_stmt.orelse.iter().enumerate(){
+                if let ast::Stmt::If(elif_stmt)= &sub_stmt.node{
+                    self.fill("el");
+                    self.walk_if_stmt(elif_stmt);
+                } else {
+                    self.fill("else:");
+                    self.write_newline_without_fill();
+                    self.write_indentation(Indentation::Indent);
+                    self.stmt(sub_stmt);
+                    self.write_indentation(Indentation::Dedent);
+                }
             }
-        } else {
-            self.write_newline_without_fill();
         }
     }
 

--- a/kclvm/ast_pretty/src/node.rs
+++ b/kclvm/ast_pretty/src/node.rs
@@ -122,8 +122,10 @@ impl<'p, 'ctx> MutSelfTypedResultWalker<'ctx> for Printer<'p> {
         self.stmts(&if_stmt.body);
         self.write_indentation(Indentation::Dedent);
         if !if_stmt.orelse.is_empty() {
-            for (_, sub_stmt) in if_stmt.orelse.iter().enumerate(){
-                if let ast::Stmt::If(elif_stmt)= &sub_stmt.node{
+            for sub_stmt in if_stmt.orelse.iter() {
+                if let ast::Stmt::If(elif_stmt) = &sub_stmt.node {
+                    // Nested if statements need to be considered,
+                    // so `el` needs to be preceded by the current indentation.
                     self.fill("el");
                     self.walk_if_stmt(elif_stmt);
                 } else {


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references:

- [ ] N
- [x] Y 

fixes #1039 

#### 2. What is the scope of this PR (e.g. component or file name):

```kclvm/ast_pretty/src/node.rs```

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

https://github.com/kcl-lang/kcl/assets/134289475/b70dd7d7-c932-4761-8857-81b2e25c0966

- Since `if_stmt.orelse` is `Vec<NodeRef<Stmt>>`, so to format the code correctly for multiple if statements inside an else block, had to iterate through all the elements of `if_stmt.orelse`.
- This approach ensures that all the if statements are formatted correctly.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

