### PR TITLE
Provided multiple quick fix options for variable modification

### DIFF
--- a/kclvm/driver/src/test_data/test_vendor/helloworld
+++ b/kclvm/driver/src/test_data/test_vendor/helloworld
@@ -1,1 +1,0 @@
-/Users/shashankmittal/Documents/Developer/lfx/kcl/kclvm/driver/src/test_data/test_vendor/helloworld_0.1.0

--- a/kclvm/driver/src/test_data/test_vendor/helloworld
+++ b/kclvm/driver/src/test_data/test_vendor/helloworld
@@ -1,0 +1,1 @@
+/Users/shashankmittal/Documents/Developer/lfx/kcl/kclvm/driver/src/test_data/test_vendor/helloworld_0.1.0

--- a/kclvm/error/src/diagnostic.rs
+++ b/kclvm/error/src/diagnostic.rs
@@ -115,7 +115,7 @@ impl Diagnostic {
                 style: Style::LineAndColumn,
                 message: message.to_string(),
                 note: note.map(String::from),
-                suggested_replacement: suggestions.and_then(|v| v.into_iter().next()),
+                suggested_replacement: suggestions,
             }],
             code,
         }
@@ -135,7 +135,7 @@ pub struct Message {
     pub style: Style,
     pub message: String,
     pub note: Option<String>,
-    pub suggested_replacement: Option<String>,
+    pub suggested_replacement: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/kclvm/error/src/error.rs
+++ b/kclvm/error/src/error.rs
@@ -157,7 +157,7 @@ pub enum WarningKind {
 ///         style: Style::LineAndColumn,
 ///         message: "Module 'a' imported but unused.".to_string(),
 ///         note: None,
-///         suggested_replacement: Some("".to_string()),
+///         suggested_replacement: None,
 ///     }],
 /// );
 /// for diag in &handler.diagnostics {
@@ -184,7 +184,7 @@ impl std::fmt::Display for WarningKind {
 ///         style: Style::LineAndColumn,
 ///         message: "Module 'a' imported but unused.".to_string(),
 ///         note: None,
-///         suggested_replacement: Some("".to_string()),
+///         suggested_replacement: None,
 ///     }],
 /// );
 /// for diag in &handler.diagnostics {

--- a/kclvm/error/src/lib.rs
+++ b/kclvm/error/src/lib.rs
@@ -165,7 +165,7 @@ impl Handler {
     ///         style: Style::LineAndColumn,
     ///         message: "Invalid syntax: expected '+', got '-'".to_string(),
     ///         note: None,
-    ///         suggested_replacement: Some("".to_string()),
+    ///         suggested_replacement: None,
     ///     }
     /// ]);
     /// ```
@@ -208,7 +208,7 @@ impl Handler {
     ///         style: Style::LineAndColumn,
     ///         message: "Module 'a' imported but unused.".to_string(),
     ///         note: None,
-    ///         suggested_replacement: Some("".to_string()),
+    ///         suggested_replacement: None,
     ///     }],
     /// );
     /// ```

--- a/kclvm/sema/src/lint/lints_def.rs
+++ b/kclvm/sema/src/lint/lints_def.rs
@@ -110,7 +110,7 @@ impl LintPass for UnusedImport {
                                 style: Style::Line,
                                 message: format!("Module '{}' imported but unused", scope_obj.name),
                                 note: Some("Consider removing this statement".to_string()),
-                                suggested_replacement: Some("".to_string()),
+                                suggested_replacement: None,
                             }],
                         );
                     }
@@ -165,7 +165,7 @@ impl LintPass for ReImport {
                                 &import_stmt.name
                             ),
                             note: Some("Consider removing this statement".to_string()),
-                            suggested_replacement: Some("".to_string()),
+                            suggested_replacement: None,
                         }],
                     );
                 } else {

--- a/kclvm/sema/src/resolver/tests.rs
+++ b/kclvm/sema/src/resolver/tests.rs
@@ -425,7 +425,7 @@ fn test_lint() {
             style: Style::Line,
             message: format!("Module 'a' is reimported multiple times"),
             note: Some("Consider removing this statement".to_string()),
-            suggested_replacement: Some("".to_string()),
+            suggested_replacement: None,
         }],
     );
     handler.add_warning(
@@ -446,7 +446,7 @@ fn test_lint() {
             style: Style::Line,
             message: format!("Module 'import_test.a' imported but unused"),
             note: Some("Consider removing this statement".to_string()),
-            suggested_replacement: Some("".to_string()),
+            suggested_replacement: None,
         }],
     );
     for (d1, d2) in resolver

--- a/kclvm/tools/src/LSP/src/tests.rs
+++ b/kclvm/tools/src/LSP/src/tests.rs
@@ -262,7 +262,7 @@ fn build_expect_diags() -> Vec<Diagnostic> {
             Some(DiagnosticSeverity::ERROR),
             vec![],
             Some(NumberOrString::String("CompileError".to_string())),
-            Some(serde_json::json!({ "suggested_replacement": ["number"] })),
+            Some(serde_json::json!({ "suggested_replacement": ["number", "n", "num"] })),
         ),
         build_lsp_diag(
             (0, 0, 0, 10),

--- a/kclvm/tools/src/LSP/src/to_lsp.rs
+++ b/kclvm/tools/src/LSP/src/to_lsp.rs
@@ -47,8 +47,14 @@ fn kcl_msg_to_lsp_diags(
     let data = msg
         .suggested_replacement
         .as_ref()
-        .filter(|s| !s.is_empty())
-        .map(|s| json!({ "suggested_replacement": [s] }));
+        .map(|s_vec| {
+            s_vec
+                .iter()
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<&String>>()
+        })
+        .filter(|v| !v.is_empty())
+        .map(|s| json!({ "suggested_replacement": s }));
 
     let related_information = if related_msg.is_empty() {
         None

--- a/kclvm/tools/src/fix/mod.rs
+++ b/kclvm/tools/src/fix/mod.rs
@@ -77,7 +77,7 @@ pub fn diag_to_suggestion(
                         file_name: msg.range.0.filename.clone(),
                         range: text_range(src.as_str(), &msg.range)?,
                     },
-                    replacement: replace.clone(),
+                    replacement: replace.first().cloned().unwrap_or_default(),
                 },
             });
         }

--- a/kclvm/tools/src/fix/mod.rs
+++ b/kclvm/tools/src/fix/mod.rs
@@ -56,31 +56,36 @@ pub struct Snippet {
 pub fn diag_to_suggestion(
     diag: Diagnostic,
     files: &mut HashMap<String, String>,
-) -> anyhow::Result<Vec<Suggestion>, Error> {
+) -> anyhow::Result<Vec<Suggestion>> {
     let mut suggestions = vec![];
 
     for msg in &diag.messages {
-        if let Some(replace) = &msg.suggested_replacement {
-            let file_name = msg.range.0.filename.clone();
-            let src = match files.get(&file_name) {
-                Some(src) => src.clone(),
-                None => {
-                    let src = fs::read_to_string(&file_name).unwrap();
-                    files.insert(file_name, src.clone());
-                    src
-                }
-            };
-            suggestions.push(Suggestion {
-                message: msg.message.clone(),
-                replacement: Replacement {
-                    snippet: Snippet {
-                        file_name: msg.range.0.filename.clone(),
-                        range: text_range(src.as_str(), &msg.range)?,
-                    },
-                    replacement: replace.first().cloned().unwrap_or_default(),
+        let replacements = msg
+            .suggested_replacement
+            .clone()
+            .unwrap_or_else(|| vec!["".to_string()]);
+        let replacement_str = replacements.first().cloned().unwrap_or_default();
+
+        let file_name = msg.range.0.filename.clone();
+        let src = match files.get(&file_name) {
+            Some(src) => src.clone(),
+            None => {
+                let src = fs::read_to_string(&file_name).expect("Unable to read file");
+                files.insert(file_name.clone(), src.clone());
+                src
+            }
+        };
+
+        suggestions.push(Suggestion {
+            message: msg.message.clone(),
+            replacement: Replacement {
+                snippet: Snippet {
+                    file_name,
+                    range: text_range(src.as_str(), &msg.range)?,
                 },
-            });
-        }
+                replacement: replacement_str,
+            },
+        });
     }
     Ok(suggestions)
 }


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references :

- [ ] N
- [x] Y 

fix #1113 

#### 2. What is the scope of this PR (e.g. component or file name):

changes to multiple files

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):


https://github.com/kcl-lang/kcl/assets/134289475/44e37c51-a6d0-4741-a2c9-362b6bdca09e



- Modified the `Message` struct from `Option<String>` to `Option<Vec<String>>`.
- Due to this I had to replace arguments which were passed to `suggested_replacement` field of `Message` struct.
- In `to_lsp.rs`, now the `suggested_replacement` key of the `data` field of `Diagnostics` is mapped to a vector of strings. 
- `extract_suggested_replacements` function in `quick_fix.rs` now returns a vector of replacement texts.
- Code Action for CompileError is iterated for each element of `replacement_texts` vector.
- Now we get multiple quick fix options for variable modification.
- Handled all the failing tests.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
