### PR TITLE
`get_schema_type` function will now return `SchemaType` instances with base schema information included

### DIFF
--- a/kclvm/api/src/service/ty.rs
+++ b/kclvm/api/src/service/ty.rs
@@ -51,7 +51,10 @@ pub(crate) fn kcl_schema_ty_to_pb_ty(schema_ty: &SchemaType) -> KclType {
         filename: schema_ty.filename.clone(),
         pkg_path: schema_ty.pkgpath.clone(),
         description: schema_ty.doc.clone(),
-        base_schema: schema_ty.base.as_ref().map(|base| kcl_schema_ty_to_pb_ty(base)),
+        base_schema: schema_ty
+            .base
+            .as_ref()
+            .map(|base| Box::new(kcl_schema_ty_to_pb_ty(&**base))),
         ..Default::default()
     }
 }

--- a/kclvm/api/src/service/ty.rs
+++ b/kclvm/api/src/service/ty.rs
@@ -51,6 +51,7 @@ pub(crate) fn kcl_schema_ty_to_pb_ty(schema_ty: &SchemaType) -> KclType {
         filename: schema_ty.filename.clone(),
         pkg_path: schema_ty.pkgpath.clone(),
         description: schema_ty.doc.clone(),
+        base_schema: schema_ty.base.as_ref().map(|base| kcl_schema_ty_to_pb_ty(base)),
         ..Default::default()
     }
 }

--- a/kclvm/query/src/query.rs
+++ b/kclvm/query/src/query.rs
@@ -189,6 +189,14 @@ pub fn get_full_schema_type(
     Ok(result)
 }
 
+fn get_full_schema_type_recursive(schema_ty: SchemaType) -> Result<SchemaType> {
+    let mut result = schema_ty;
+    if let Some(base) = result.base {
+        result.base = Some(Box::new(get_full_schema_type_recursive(*base)?));
+    }
+    Ok(result)
+}
+
 fn resolve_file(opts: &CompilationOptions) -> Result<Rc<RefCell<Scope>>> {
     let sess = Arc::new(ParseSession::default());
     let mut program = match load_program(

--- a/kclvm/query/src/query.rs
+++ b/kclvm/query/src/query.rs
@@ -164,7 +164,10 @@ pub fn get_full_schema_type(
     let scope = resolve_file(&opts)?;
     for (name, o) in &scope.borrow().elems {
         if o.borrow().ty.is_schema() {
-            let schema_ty = o.borrow().ty.into_schema_type();
+            let mut schema_ty = o.borrow().ty.into_schema_type();
+            if let Some(base) = &schema_ty.base {
+                schema_ty.base = Some(Box::new(get_full_schema_type_recursive(*base.clone())?));
+            }
             if opts.get_schema_opts == GetSchemaOption::All
                 || (opts.get_schema_opts == GetSchemaOption::Definitions && !schema_ty.is_instance)
                 || (opts.get_schema_opts == GetSchemaOption::Instances && schema_ty.is_instance)

--- a/kclvm/spec/gpyrpc/gpyrpc.proto
+++ b/kclvm/spec/gpyrpc/gpyrpc.proto
@@ -477,6 +477,7 @@ message KclType {
 	string pkg_path = 13;                // `pkg_path` represents the path name of the package where the attribute is located.
 	string description = 14;             // `description` represents the document of the attribute.
 	map<string, Example> examples = 15;  // A map object to hold examples, the key is the example name.
+	KclType base_schema = 16;
 }
 
 message Decorator {


### PR DESCRIPTION

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [ ✅] Y 
 fix #1215 

#### 2. What is the scope of this PR (e.g. component or file name):

`kclvm/query/src/query.rs`
`kclvm/spec/gpyrpc/gpyrpc.proto`
`kclvm/api/src/service/ty.rs`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

the `get_schema_type` function will return `SchemaType` instances with base schema information included, while the `get_full_schema_type` function will return `SchemaType` instances with the complete inheritance hierarchy resolved

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ✅] N
- [ ] Y 


#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

N