### PR TITLE
fix: fix the inconsistency in filename drive letters

### DIFF
--- a/kclvm/Cargo.lock
+++ b/kclvm/Cargo.lock
@@ -1521,6 +1521,7 @@ dependencies = [
  "kclvm-runtime",
  "kclvm-sema",
  "kclvm-tools",
+ "kclvm-utils",
  "maplit",
  "once_cell",
  "prost",
@@ -1913,6 +1914,7 @@ version = "0.8.6"
 dependencies = [
  "anyhow",
  "fslock",
+ "regex",
 ]
 
 [[package]]

--- a/kclvm/Cargo.lock
+++ b/kclvm/Cargo.lock
@@ -1545,6 +1545,7 @@ dependencies = [
  "kclvm-error",
  "kclvm-parser",
  "kclvm-span",
+ "kclvm-utils",
  "serde",
  "serde_json",
  "thread_local",

--- a/kclvm/api/Cargo.toml
+++ b/kclvm/api/Cargo.toml
@@ -32,6 +32,7 @@ kclvm-runtime = {path = "../runtime"}
 kclvm-tools = {path = "../tools" }
 kclvm-query = {path = "../query"}
 kcl-language-server = {path = "../tools/src/LSP"}
+kclvm-utils = {path = "../utils"}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 jsonrpc-stdio-server = "18.0.0"

--- a/kclvm/ast/Cargo.toml
+++ b/kclvm/ast/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1.0"
 kclvm-span = { path = "../span" }
 kclvm-error = { path = "../error" }
 thread_local = "1.1.7"
+kclvm-utils = {path = "../utils"}
 
 [dev-dependencies]
 kclvm-parser = { path = "../parser" }

--- a/kclvm/ast/src/ast.rs
+++ b/kclvm/ast/src/ast.rs
@@ -33,6 +33,7 @@
 //! in the compiler and regenerate the walker code.
 //! :copyright: Copyright The KCL Authors. All rights reserved.
 
+use kclvm_utils::path::fix_windows_filename_canonicalization;
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
 
@@ -200,7 +201,10 @@ impl<T> Node<T> {
         Self {
             id: AstIndex::default(),
             node,
-            filename: format!("{}", lo.file.name.prefer_remapped()),
+            filename: fix_windows_filename_canonicalization(&format!(
+                "{}",
+                lo.file.name.prefer_remapped()
+            )),
             line: lo.line as u64,
             column: lo.col.0 as u64,
             end_line: hi.line as u64,

--- a/kclvm/parser/src/parser/mod.rs
+++ b/kclvm/parser/src/parser/mod.rs
@@ -87,7 +87,7 @@ impl<'a> Parser<'a> {
 
         #[cfg(windows)]
         {
-            // The canonicalize() function will change the drive letter to uppercase in Windows. 
+            // The canonicalize() function will change the drive letter to uppercase in Windows.
             // e.g.: c:\\xx -> C:\\xx
             // To be consistent with the rest, all capital letters have been changed here
             let file = std::path::Path::new(filename).canonicalize().unwrap();

--- a/kclvm/parser/src/parser/mod.rs
+++ b/kclvm/parser/src/parser/mod.rs
@@ -31,6 +31,7 @@ use kclvm_ast::ast::{Comment, NodeRef, PosTuple};
 use kclvm_ast::token::{CommentKind, Token, TokenKind};
 use kclvm_ast::token_stream::{Cursor, TokenStream};
 use kclvm_span::symbol::Symbol;
+use kclvm_utils::path::PathPrefix;
 
 /// The parser is built on top of the [`kclvm_parser::lexer`], and ordering KCL tokens
 /// [`kclvm_ast::token`] to KCL ast nodes [`kclvm_ast::ast`].
@@ -83,6 +84,22 @@ impl<'a> Parser<'a> {
         let hi = self.sess.lookup_char_pos(hi);
 
         let filename: String = format!("{}", lo.file.name.prefer_remapped());
+
+        #[cfg(windows)]
+        {
+            // The canonicalize() function will change the drive letter to uppercase in Windows. 
+            // e.g.: c:\\xx -> C:\\xx
+            // To be consistent with the rest, all capital letters have been changed here
+            let file = std::path::Path::new(filename).canonicalize().unwrap();
+            let case_insensitive_filename = file.adjust_canonicalization();
+            return (
+                case_insensitive_filename,
+                lo.line as u64,
+                lo.col.0 as u64,
+                hi.line as u64,
+                hi.col.0 as u64,
+            );
+        }
         (
             filename,
             lo.line as u64,

--- a/kclvm/parser/src/parser/mod.rs
+++ b/kclvm/parser/src/parser/mod.rs
@@ -31,7 +31,6 @@ use kclvm_ast::ast::{Comment, NodeRef, PosTuple};
 use kclvm_ast::token::{CommentKind, Token, TokenKind};
 use kclvm_ast::token_stream::{Cursor, TokenStream};
 use kclvm_span::symbol::Symbol;
-use kclvm_utils::path::PathPrefix;
 
 /// The parser is built on top of the [`kclvm_parser::lexer`], and ordering KCL tokens
 /// [`kclvm_ast::token`] to KCL ast nodes [`kclvm_ast::ast`].
@@ -85,14 +84,14 @@ impl<'a> Parser<'a> {
 
         let filename: String = format!("{}", lo.file.name.prefer_remapped());
 
-        #[cfg(windows)]
+        #[cfg(target_os = "windows")]
         {
+            use kclvm_utils::path::PathPrefix;
             // The canonicalize() function will change the drive letter to uppercase in Windows.
             // e.g.: c:\\xx -> C:\\xx
-            // To be consistent with the rest, all capital letters have been changed here
             let file = std::path::Path::new(filename).canonicalize().unwrap();
             let case_insensitive_filename = file.adjust_canonicalization();
-            return (
+            (
                 case_insensitive_filename,
                 lo.line as u64,
                 lo.col.0 as u64,
@@ -100,13 +99,16 @@ impl<'a> Parser<'a> {
                 hi.col.0 as u64,
             );
         }
-        (
-            filename,
-            lo.line as u64,
-            lo.col.0 as u64,
-            hi.line as u64,
-            hi.col.0 as u64,
-        )
+        #[cfg(not(target_os = "windows"))]
+        {
+            (
+                filename,
+                lo.line as u64,
+                lo.col.0 as u64,
+                hi.line as u64,
+                hi.col.0 as u64,
+            )
+        }
     }
 
     pub(crate) fn bump(&mut self) {

--- a/kclvm/parser/src/parser/mod.rs
+++ b/kclvm/parser/src/parser/mod.rs
@@ -89,7 +89,7 @@ impl<'a> Parser<'a> {
             use kclvm_utils::path::PathPrefix;
             // The canonicalize() function will change the drive letter to uppercase in Windows.
             // e.g.: c:\\xx -> C:\\xx
-            let file = std::path::Path::new(filename).canonicalize().unwrap();
+            let file = std::path::Path::new(&filename).canonicalize().unwrap();
             let case_insensitive_filename = file.adjust_canonicalization();
             (
                 case_insensitive_filename,
@@ -97,7 +97,7 @@ impl<'a> Parser<'a> {
                 lo.col.0 as u64,
                 hi.line as u64,
                 hi.col.0 as u64,
-            );
+            )
         }
         #[cfg(not(target_os = "windows"))]
         {

--- a/kclvm/parser/src/parser/mod.rs
+++ b/kclvm/parser/src/parser/mod.rs
@@ -89,15 +89,25 @@ impl<'a> Parser<'a> {
             use kclvm_utils::path::PathPrefix;
             // The canonicalize() function will change the drive letter to uppercase in Windows.
             // e.g.: c:\\xx -> C:\\xx
-            let file = std::path::Path::new(&filename).canonicalize().unwrap();
-            let case_insensitive_filename = file.adjust_canonicalization();
-            (
-                case_insensitive_filename,
-                lo.line as u64,
-                lo.col.0 as u64,
-                hi.line as u64,
-                hi.col.0 as u64,
-            )
+            match std::path::Path::new(&filename).canonicalize() {
+                Ok(file) => {
+                    let case_insensitive_filename = file.adjust_canonicalization();
+                    (
+                        case_insensitive_filename,
+                        lo.line as u64,
+                        lo.col.0 as u64,
+                        hi.line as u64,
+                        hi.col.0 as u64,
+                    )
+                }
+                Err(_) => (
+                    filename,
+                    lo.line as u64,
+                    lo.col.0 as u64,
+                    hi.line as u64,
+                    hi.col.0 as u64,
+                ),
+            }
         }
         #[cfg(not(target_os = "windows"))]
         {

--- a/kclvm/utils/Cargo.toml
+++ b/kclvm/utils/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
+regex = "1.3"
+
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fslock = "0.2.1"

--- a/kclvm/utils/src/path.rs
+++ b/kclvm/utils/src/path.rs
@@ -70,6 +70,22 @@ where
     }
 }
 
+pub fn fix_windows_filename_canonicalization(filename: &String) -> String {
+    #[cfg(target_os = "windows")]
+    {
+        // The canonicalize() function will change the drive letter to uppercase in Windows.
+        // e.g.: c:\\xx -> C:\\xx
+        match std::path::Path::new(&filename).canonicalize() {
+            Ok(file) => file.adjust_canonicalization(),
+            Err(_) => filename.clone(),
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        filename.clone()
+    }
+}
+
 #[test]
 #[cfg(target_os = "windows")]
 fn test_adjust_canonicalization() {

--- a/kclvm/utils/src/path.rs
+++ b/kclvm/utils/src/path.rs
@@ -70,20 +70,29 @@ where
     }
 }
 
-pub fn fix_windows_filename_canonicalization(filename: &String) -> String {
-    #[cfg(target_os = "windows")]
+/// Conver windows drive letter to upcase
+#[cfg(target_os = "windows")]
+pub fn convert_windows_drive_letter(path: &str) -> String {
     {
-        // The canonicalize() function will change the drive letter to uppercase in Windows.
-        // e.g.: c:\\xx -> C:\\xx
-        match std::path::Path::new(&filename).canonicalize() {
-            Ok(file) => file.adjust_canonicalization(),
-            Err(_) => filename.clone(),
+        let regex = regex::Regex::new(r"(?i)^\\\\\?\\[a-z]:\\").unwrap();
+        const VERBATIM_PREFIX: &str = r#"\\?\"#;
+        let mut p = path.to_string();
+        if p.starts_with(VERBATIM_PREFIX) && regex.is_match(&p) {
+            let drive_letter = p[VERBATIM_PREFIX.len()..VERBATIM_PREFIX.len() + 1].to_string();
+            p.replace_range(
+                VERBATIM_PREFIX.len()..VERBATIM_PREFIX.len() + 1,
+                &drive_letter.to_uppercase(),
+            );
         }
+        p
     }
-    #[cfg(not(target_os = "windows"))]
-    {
-        filename.clone()
-    }
+}
+
+#[test]
+#[cfg(target_os = "windows")]
+fn test_convert_drive_letter() {
+    let path = r"\\?\d:\xx";
+    assert_eq!(convert_windows_drive_letter(path), r"\\?\D:\xx".to_string())
 }
 
 #[test]


### PR DESCRIPTION
  fix the inconsistency in filename drive letters in Windows caused bycanonicalize() function

<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y  fix https://github.com/kcl-lang/kcl/issues/1251

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):
kclvm/parser/src/parser/mod.rs
<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
