### PR TITLE
Syntax highlight in hover

### DIFF
--- a/kclvm/tools/src/LSP/src/hover.rs
+++ b/kclvm/tools/src/LSP/src/hover.rs
@@ -129,13 +129,23 @@ fn docs_to_hover(docs: Vec<String>) -> Option<lsp_types::Hover> {
     match docs.len() {
         0 => None,
         1 => Some(Hover {
-            contents: HoverContents::Scalar(MarkedString::String(docs[0].clone())),
+            contents: HoverContents::Scalar(MarkedString::LanguageString(
+                lsp_types::LanguageString {
+                    language: "kcl".to_string(),
+                    value: docs[0].clone(),
+                },
+            )),
             range: None,
         }),
         _ => Some(Hover {
             contents: HoverContents::Array(
                 docs.iter()
-                    .map(|doc| MarkedString::String(doc.clone()))
+                    .map(|doc| {
+                        MarkedString::LanguageString(lsp_types::LanguageString {
+                            language: "kcl".to_string(),
+                            value: doc.clone(),
+                        })
+                    })
                     .collect(),
             ),
             range: None,


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y #1304 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->
/tools/src/LSP/src/hover.rs

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other
It provides syntax highlight to hover text. It does so by using MarkedString::LanguageString and MarkedString::String.

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->
This fixes the formatting as seen below.
<img width="1168" alt="image" src="https://github.com/kcl-lang/kcl/assets/110763795/a3cdc35e-bb03-46f1-8ba4-32dfe90db922">


However, this has a problem. It doesn't work on neovim unless you set the language as "kwt" instead of kcl. Therefore, please check if this is case for you as well.
<img width="1168" alt="image" src="https://github.com/kcl-lang/kcl/assets/110763795/b266555d-3c6a-4700-a2e6-a2641c98c6ae">


#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
I have currently not written tests for this. Please tell me if this is the right solution and then I will write the test cases.
