### PR TITLE
quick fixes for some compile errors using ast

### DIFF
--- a/kclvm/sema/src/resolver/global.rs
+++ b/kclvm/sema/src/resolver/global.rs
@@ -481,19 +481,12 @@ impl<'ctx> Resolver<'ctx> {
             );
         }
         if schema_stmt.is_protocol && !name.ends_with(PROTOCOL_SUFFIX) {
-            let fix_range = schema_stmt.name.get_span_pos();
-            let (start_pos, end_pos) = fix_range;
-            let start_column = end_pos.column;
-
-            let modified_start_pos = Position {
-                column: start_column,
-                ..start_pos.clone()
-            };
-            let modified_fix_range = (modified_start_pos, end_pos);
-
             self.handler.add_compile_error_with_suggestions(
                 &format!("schema protocol name must end with '{}'", PROTOCOL_SUFFIX),
-                modified_fix_range,
+                (
+                    schema_stmt.name.get_end_pos(),
+                    schema_stmt.name.get_end_pos(),
+                ),
                 Some(vec![PROTOCOL_SUFFIX.to_string()]),
             );
         }


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

- fixed range for some compile errors using ast by removing the redundant code of modifying the fix range.
- introduced new variables to store the end position span of the previous target or keyword.

1. 
```
data = {key1 = "value1", key2 = "value2"}
dataKeys2 = {k: k for k, v, k in data}
``` 
will be fixed as
```
data = {key1 = "value1", key2 = "value2"}
dataKeys2 = {k: k for k, v in data}
``` 
2.
```
protocol Person:
    firstName: str
    lastName: str
    fullName?: str
``` 
will be fixed as 
```
protocol PersonProtocol:
    firstName: str
    lastName: str
    fullName?: str
``` 
3.
```
import .model1

model1?.CatalogItem
``` 
will be fixed as
```
import .model1

model1.CatalogItem
``` 

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
