### PR TITLE
fix: allow setting PROTOC environment variable

### DIFF
--- a/kclvm/api/build.rs
+++ b/kclvm/api/build.rs
@@ -5,10 +5,12 @@ use prost_wkt_build::{FileDescriptorSet, Message};
 /// According to the file kclvm/spec/gpyrpc/gpyrpc.proto, automatically generate
 /// the corresponding rust source file to the directory src/model
 fn main() {
-    std::env::set_var(
-        "PROTOC",
-        protoc_bin_vendored::protoc_bin_path().unwrap().as_os_str(),
-    );
+    if env::var("PROTOC").is_err() {
+        env::set_var(
+            "PROTOC",
+            protoc_bin_vendored::protoc_bin_path().unwrap().as_os_str(),
+        );
+    }
 
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());
     let descriptor_file = out.join("kclvm_service_descriptor.bin");

--- a/kclvm/third-party/prost-wkt/wkt-types/build.rs
+++ b/kclvm/third-party/prost-wkt/wkt-types/build.rs
@@ -13,10 +13,12 @@ use regex::Regex;
 
 fn main() {
     //hack: set protoc_bin_vendored::protoc_bin_path() to PROTOC
-    std::env::set_var(
-        "PROTOC",
-        protoc_bin_vendored::protoc_bin_path().unwrap().as_os_str(),
-    );
+    if env::var("PROTOC").is_err() {
+        env::set_var(
+            "PROTOC",
+            protoc_bin_vendored::protoc_bin_path().unwrap().as_os_str(),
+        );
+    }
     let dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     process_prost_pbtime(&dir);
 


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->
fix #1413

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->
kclvm/third-party/prost-wkt/wkt-types/build.rs
kclvm/api/build.rs

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->
This fix ensures that if the PROTOC environment variable is already set, it will be used; otherwise, it defaults to using the protoc_bin_vendored binaries. This improves the flexibility of the protocol buffer compiler setup.


#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

No tests seams to be required for this change as the integration is pretty straightforward.

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
