### PR TITLE
fix: capi input arguments

### DIFF
--- a/kclvm/api/src/lib.rs
+++ b/kclvm/api/src/lib.rs
@@ -37,7 +37,7 @@ pub use crate::gpyrpc::*;
 use crate::service::capi::{kclvm_service_call_with_length, kclvm_service_new};
 use crate::service::service_impl::KclvmServiceImpl;
 use anyhow::Result;
-use std::ffi::CString;
+use std::ffi::c_char;
 
 pub type API = KclvmServiceImpl;
 
@@ -55,10 +55,15 @@ pub fn call_with_plugin_agent<'a>(
 ) -> Result<Vec<u8>> {
     let mut result_len: usize = 0;
     let result_ptr = {
-        let args = unsafe { CString::from_vec_unchecked(args.to_vec()) };
-        let call = unsafe { CString::from_vec_unchecked(name.to_vec()) };
         let serv = kclvm_service_new(plugin_agent);
-        kclvm_service_call_with_length(serv, call.as_ptr(), args.as_ptr(), &mut result_len)
+        kclvm_service_call_with_length(
+            serv,
+            name.as_ptr() as *const c_char,
+            name.len(),
+            args.as_ptr() as *const c_char,
+            name.len(),
+            &mut result_len,
+        )
     };
     let result = unsafe {
         let mut dest_data: Vec<u8> = Vec::with_capacity(result_len);


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

+ fix: capi input arguments

Added 'args length' to the input parameters of CAPI, as there may be '0' in the bytes of protobuf serialization.
