### PR TITLE
chore: bump rust 1.91 and edition 2024 & fix all lint issues in compiler_base

### DIFF
--- a/.github/workflows/compiler_base_test.yaml
+++ b/.github/workflows/compiler_base_test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: 1.91
           override: true
           components: clippy, rustfmt
 
@@ -40,10 +40,15 @@ jobs:
       - name: Install rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: 1.91
           override: true
           components: clippy, rustfmt
-      - name: Compiler_base rust unit test
+      - name: Format
         working-directory: ./compiler_base
-        run: make test
-        shell: bash
+        run: cargo clippy --workspace --all-features --benches --examples --tests -- -D warnings
+      - name: Lint
+        working-directory: ./compiler_base
+        run: cargo fmt --all -- --check
+      - name: Unit test
+        working-directory: ./compiler_base
+        run: cargo test -r --workspace --all-features

--- a/.github/workflows/macos_arm_test.yaml
+++ b/.github/workflows/macos_arm_test.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: 1.91
           override: true
           components: clippy, rustfmt
       - name: Set up python

--- a/.github/workflows/macos_test.yaml
+++ b/.github/workflows/macos_test.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Install rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: 1.91
           override: true
           components: clippy, rustfmt
       - name: Code format check

--- a/.github/workflows/ubuntu_arm_test.yaml
+++ b/.github/workflows/ubuntu_arm_test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: 1.91
           override: true
           components: clippy, rustfmt
       - name: Code format check

--- a/.github/workflows/ubuntu_test.yaml
+++ b/.github/workflows/ubuntu_test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: 1.91
           override: true
           components: clippy, rustfmt
       - name: Code format check

--- a/.github/workflows/wasm_test.yaml
+++ b/.github/workflows/wasm_test.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: 1.91
           override: true
           components: clippy, rustfmt
 

--- a/.github/workflows/windows_mingw_test.yaml
+++ b/.github/workflows/windows_mingw_test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: 1.91
           override: true
           components: clippy, rustfmt
 

--- a/.github/workflows/windows_test.yaml
+++ b/.github/workflows/windows_test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88
+          toolchain: 1.91
           override: true
           components: clippy, rustfmt
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Ant Group, Youzan, and Huawei are notable production users managing large-scale 
 ### Primary Language: Rust
 - 362+ Rust source files
 - ~32,673 lines of Rust code in core modules
-- **Requires Rust 1.88+** for building
+- **Requires Rust 1.91+** for building
 - Rust 2024 edition
 
 ### Secondary Languages
@@ -245,7 +245,7 @@ Comprehensive GitHub Actions workflows (11 pipelines) for:
 docker pull kcllang/kcl-builder
 
 # Or install dependencies locally
-# - Rust 1.88+
+# - Rust 1.91+
 # - Python 3.x (for tests)
 # - Protobuf compiler
 

--- a/compiler_base/3rdparty/rustc_data_structures/Cargo.toml
+++ b/compiler_base/3rdparty/rustc_data_structures/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustc_data_structures"
 version = "0.1.2"
-edition = "2021"
+edition.workspace = true
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"
 description = "Reuse rustc_data_structures for compiler_base"

--- a/compiler_base/3rdparty/rustc_data_structures/src/base_n.rs
+++ b/compiler_base/3rdparty/rustc_data_structures/src/base_n.rs
@@ -6,12 +6,12 @@ pub const MAX_BASE: usize = 64;
 pub const ALPHANUMERIC_ONLY: usize = 62;
 pub const CASE_INSENSITIVE: usize = 36;
 
-const BASE_64: &[u8; MAX_BASE as usize] =
+const BASE_64: &[u8; MAX_BASE] =
     b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@$";
 
 #[inline]
 pub fn push_str(mut n: u128, base: usize, output: &mut String) {
-    debug_assert!(base >= 2 && base <= MAX_BASE);
+    debug_assert!((2..=MAX_BASE).contains(&base));
     let mut s = [0u8; 128];
     let mut index = 0;
 

--- a/compiler_base/3rdparty/rustc_data_structures/src/flock.rs
+++ b/compiler_base/3rdparty/rustc_data_structures/src/flock.rs
@@ -38,7 +38,7 @@ cfg_if! {
                     .read(true)
                     .write(true)
                     .create(create)
-                    .mode(libc::S_IRWXU as u32)
+                    .mode(libc::S_IRWXU)
                     .open(p)?;
 
                 let mut operation = if exclusive {

--- a/compiler_base/3rdparty/rustc_data_structures/src/lib.rs
+++ b/compiler_base/3rdparty/rustc_data_structures/src/lib.rs
@@ -37,8 +37,8 @@ pub mod flock;
 
 pub mod macros;
 pub use ena::snapshot_vec;
-#[macro_use]
 
+#[macro_use]
 pub mod sync;
 pub mod frozen;
 

--- a/compiler_base/3rdparty/rustc_data_structures/src/temp_dir.rs
+++ b/compiler_base/3rdparty/rustc_data_structures/src/temp_dir.rs
@@ -16,7 +16,7 @@ impl Drop for MaybeTempDir {
         // occur.
         let dir = unsafe { ManuallyDrop::take(&mut self.dir) };
         if self.keep {
-            let _ = dir.into_path();
+            let _ = dir.keep();
         }
     }
 }

--- a/compiler_base/3rdparty/rustc_errors/Cargo.toml
+++ b/compiler_base/3rdparty/rustc_errors/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustc_errors"
 version = "0.1.2"
-edition = "2021"
+edition.workspace = true
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"
 description = "Reuse rustc_errors for compiler_base"

--- a/compiler_base/3rdparty/rustc_errors/src/lib.rs
+++ b/compiler_base/3rdparty/rustc_errors/src/lib.rs
@@ -52,8 +52,8 @@ pub trait Style {
 #[cfg(test)]
 mod test_styled_buffer {
     use crate::{
-        styled_buffer::{StyledBuffer, StyledString},
         Style,
+        styled_buffer::{StyledBuffer, StyledString},
     };
     use termcolor::{Color, ColorSpec};
 
@@ -113,25 +113,31 @@ mod test_styled_buffer {
 
     fn require_hello_world(styled_strings: Vec<Vec<StyledString<DummyStyle>>>) {
         assert_eq!(styled_strings.len(), 1);
-        assert_eq!(styled_strings.get(0).unwrap().len(), 2);
+        assert_eq!(styled_strings.first().unwrap().len(), 2);
 
-        assert_eq!(styled_strings.get(0).unwrap().get(0).unwrap().text, "Hello");
+        assert_eq!(
+            styled_strings.first().unwrap().first().unwrap().text,
+            "Hello"
+        );
         assert!(
             DummyStyle::NoStyle
                 == *styled_strings
-                    .get(0)
+                    .first()
                     .unwrap()
-                    .get(0)
+                    .first()
                     .unwrap()
                     .style
                     .as_ref()
                     .unwrap()
         );
-        assert_eq!(styled_strings.get(0).unwrap().get(1).unwrap().text, "World");
+        assert_eq!(
+            styled_strings.first().unwrap().get(1).unwrap().text,
+            "World"
+        );
         assert!(
             DummyStyle::Dummy
                 == *styled_strings
-                    .get(0)
+                    .first()
                     .unwrap()
                     .get(1)
                     .unwrap()
@@ -156,13 +162,16 @@ mod test_styled_buffer {
         sb.putc(0, 3, 'L', Some(DummyStyle::NoStyle));
         sb.putc(0, 4, 'O', Some(DummyStyle::NoStyle));
         let styled_strings = sb.render();
-        assert_eq!(styled_strings.get(0).unwrap().get(0).unwrap().text, "HELLO");
+        assert_eq!(
+            styled_strings.first().unwrap().first().unwrap().text,
+            "HELLO"
+        );
         assert!(
             DummyStyle::NoStyle
                 == *styled_strings
-                    .get(0)
+                    .first()
                     .unwrap()
-                    .get(0)
+                    .first()
                     .unwrap()
                     .style
                     .as_ref()
@@ -180,16 +189,16 @@ mod test_styled_buffer {
         sb.putc(2, 0, 'A', Some(DummyStyle::Dummy));
         let styled_strings = sb.render();
         assert_eq!(styled_strings.len(), 3);
-        assert_eq!(styled_strings.get(0).unwrap().len(), 2);
+        assert_eq!(styled_strings.first().unwrap().len(), 2);
         assert_eq!(styled_strings.get(1).unwrap().len(), 0);
         assert_eq!(styled_strings.get(2).unwrap().len(), 1);
-        assert_eq!(styled_strings.get(2).unwrap().get(0).unwrap().text, "A");
+        assert_eq!(styled_strings.get(2).unwrap().first().unwrap().text, "A");
         assert!(
             DummyStyle::Dummy
                 == *styled_strings
                     .get(2)
                     .unwrap()
-                    .get(0)
+                    .first()
                     .unwrap()
                     .style
                     .as_ref()
@@ -215,16 +224,16 @@ mod test_styled_buffer {
         sb.puts(2, 0, "A", Some(DummyStyle::Dummy));
         let styled_strings = sb.render();
         assert_eq!(styled_strings.len(), 3);
-        assert_eq!(styled_strings.get(0).unwrap().len(), 2);
+        assert_eq!(styled_strings.first().unwrap().len(), 2);
         assert_eq!(styled_strings.get(1).unwrap().len(), 0);
         assert_eq!(styled_strings.get(2).unwrap().len(), 1);
-        assert_eq!(styled_strings.get(2).unwrap().get(0).unwrap().text, "A");
+        assert_eq!(styled_strings.get(2).unwrap().first().unwrap().text, "A");
         assert!(
             DummyStyle::Dummy
                 == *styled_strings
                     .get(2)
                     .unwrap()
-                    .get(0)
+                    .first()
                     .unwrap()
                     .style
                     .as_ref()
@@ -240,15 +249,18 @@ mod test_styled_buffer {
         pushs_hello_world(&mut sb);
         let styled_strings = sb.render();
         assert_eq!(styled_strings.len(), 2);
-        assert_eq!(styled_strings.get(0).unwrap().len(), 1);
+        assert_eq!(styled_strings.first().unwrap().len(), 1);
 
-        assert_eq!(styled_strings.get(0).unwrap().get(0).unwrap().text, "Hello");
+        assert_eq!(
+            styled_strings.first().unwrap().first().unwrap().text,
+            "Hello"
+        );
         assert!(
             DummyStyle::NoStyle
                 == *styled_strings
-                    .get(0)
+                    .first()
                     .unwrap()
-                    .get(0)
+                    .first()
                     .unwrap()
                     .style
                     .as_ref()
@@ -257,13 +269,16 @@ mod test_styled_buffer {
             DummyStyle::NoStyle
         );
 
-        assert_eq!(styled_strings.get(1).unwrap().get(0).unwrap().text, "World");
+        assert_eq!(
+            styled_strings.get(1).unwrap().first().unwrap().text,
+            "World"
+        );
         assert!(
             DummyStyle::Dummy
                 == *styled_strings
                     .get(1)
                     .unwrap()
-                    .get(0)
+                    .first()
                     .unwrap()
                     .style
                     .as_ref()

--- a/compiler_base/3rdparty/rustc_errors/src/styled_buffer.rs
+++ b/compiler_base/3rdparty/rustc_errors/src/styled_buffer.rs
@@ -68,6 +68,15 @@ where
     }
 }
 
+impl<T> Default for StyledBuffer<T>
+where
+    T: Clone + PartialEq + Eq + Style,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> StyledBuffer<T>
 where
     T: Clone + PartialEq + Eq + Style,
@@ -146,10 +155,8 @@ where
     /// It will add an new empty line after all the buffer lines for the `string`.
     pub fn pushs(&mut self, string: &str, style: Option<T>) {
         let line = self.num_lines();
-        let mut col = 0;
-        for c in string.chars() {
+        for (col, c) in string.chars().enumerate() {
             self.putc(line, col, c, style.clone());
-            col += 1;
         }
     }
 

--- a/compiler_base/3rdparty/rustc_span/Cargo.toml
+++ b/compiler_base/3rdparty/rustc_span/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustc_span"
 version = "0.1.2"
-edition = "2021"
+edition.workspace = true
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"
 description = "Reuse rustc_span for compiler_base"

--- a/compiler_base/3rdparty/rustc_span/src/caching_source_map_view.rs
+++ b/compiler_base/3rdparty/rustc_span/src/caching_source_map_view.rs
@@ -173,7 +173,7 @@ impl<'sm> CachingSourceMapView<'sm> {
             Some(new_file_and_idx)
         } else {
             let file = &self.line_cache[oldest].file;
-            if !file_contains(&file, span_data.hi) {
+            if !file_contains(file, span_data.hi) {
                 return None;
             }
 

--- a/compiler_base/Cargo.toml
+++ b/compiler_base/Cargo.toml
@@ -1,20 +1,3 @@
-[package]
-name = "compiler_base"
-version = "0.1.4"
-edition = "2021"
-authors = ["zongzhe1024@163.com"]
-license = "Apache-2.0 OR MIT"
-description = "A common domain programming language framework."
-readme = "README.md"
-homepage = "https://github.com/kcl-lang/kcl"
-repository = "https://github.com/kcl-lang/kcl"
-keywords = ["compiler"]
-categories = ["command-line-utilities"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-
 [workspace]
 members = [
     "session",
@@ -26,3 +9,18 @@ members = [
     "3rdparty/rustc_data_structures",
     "3rdparty/rustc_span",
 ]
+resolver = "2"
+
+[workspace.package]
+version = "0.2.0"
+edition = "2024"
+rust-version = "1.83"
+authors = ["zongzhe1024@163.com"]
+exclude = [".github/"]
+license = "Apache-2.0"
+readme = "README.md"
+description = "A common domain programming language framework."
+homepage = "https://github.com/kcl-lang/kcl"
+repository = "https://github.com/kcl-lang/kcl"
+keywords = ["compiler"]
+categories = ["command-line-utilities"]

--- a/compiler_base/error/Cargo.toml
+++ b/compiler_base/error/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compiler_base_error"
 version = "0.1.6"
-edition = "2021"
+edition.workspace = true
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"
 description = "compiler_base_error"

--- a/compiler_base/error/src/diagnostic/components.rs
+++ b/compiler_base/error/src/diagnostic/components.rs
@@ -1,9 +1,9 @@
 //! 'components.rs' defines all components with style `DiagnosticStyle` that builtin in compiler_base_error.
 use std::{cmp::Ordering, sync::Arc};
 
-use super::{style::DiagnosticStyle, Component};
+use super::{Component, style::DiagnosticStyle};
 use crate::errors::ComponentFormatError;
-use compiler_base_span::{span_to_filename_string, SourceFile, SourceMap, Span};
+use compiler_base_span::{SourceFile, SourceMap, Span, span_to_filename_string};
 use rustc_errors::styled_buffer::{StyledBuffer, StyledString};
 use rustc_span::LineInfo;
 

--- a/compiler_base/error/src/diagnostic/diagnostic_message.rs
+++ b/compiler_base/error/src/diagnostic/diagnostic_message.rs
@@ -1,10 +1,12 @@
+#![allow(clippy::arc_with_non_send_sync)]
+
 //! The crate provides `TemplateLoader` to load the diagnositc message displayed in diagnostics from "*.ftl" files,
 //! `TemplateLoader` relies on 'fluent0.16.0' to support loading diagnositc message from "*.ftl" files.
 //!
 //! 'fluent0.16.0' is used to support diagnostic text template.
 //! For more information about 'fluent0.16.0', see https://projectfluent.org/.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use fluent::{FluentBundle, FluentResource};
 use std::{fs, sync::Arc};
 use unic_langid::langid;

--- a/compiler_base/error/src/diagnostic/mod.rs
+++ b/compiler_base/error/src/diagnostic/mod.rs
@@ -1,6 +1,6 @@
 use crate::errors::ComponentFormatError;
-pub use rustc_errors::styled_buffer::{StyledBuffer, StyledString};
 use rustc_errors::Style;
+pub use rustc_errors::styled_buffer::{StyledBuffer, StyledString};
 use std::fmt::Debug;
 
 pub mod components;

--- a/compiler_base/error/src/emitter.rs
+++ b/compiler_base/error/src/emitter.rs
@@ -11,14 +11,14 @@
 //! For more information about how to define your customized `Emitter`, see the doc above `Emitter` trait.
 
 use crate::{
+    DiagnosticStyle,
     diagnostic::{Component, Diagnostic},
     errors::ComponentError,
-    DiagnosticStyle,
 };
 use anyhow::Result;
 use rustc_errors::{
-    styled_buffer::{StyledBuffer, StyledString},
     Style,
+    styled_buffer::{StyledBuffer, StyledString},
 };
 use std::fmt::Debug;
 use std::io::{self, Write};
@@ -322,18 +322,18 @@ impl<'a> Write for Destination<'a> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        match *self {
-            Self::Terminal(ref mut t) => t.flush(),
-            Self::Buffered(_, ref mut buf) => buf.flush(),
-            Self::UnColoredRaw(ref mut w) => w.flush(),
-            Self::ColoredRaw(ref mut w) => w.flush(),
+        match self {
+            Self::Terminal(t) => t.flush(),
+            Self::Buffered(_, buf) => buf.flush(),
+            Self::UnColoredRaw(w) => w.flush(),
+            Self::ColoredRaw(w) => w.flush(),
         }
     }
 }
 
 impl<'a> Drop for Destination<'a> {
     fn drop(&mut self) {
-        if let Destination::Buffered(ref mut dst, ref mut buf) = self {
+        if let Destination::Buffered(dst, buf) = &self {
             drop(dst.print(buf));
         }
     }

--- a/compiler_base/error/src/lib.rs
+++ b/compiler_base/error/src/lib.rs
@@ -4,7 +4,7 @@
 //! by separating out error thorwing and diagnostic diaplaying or other error handling procedures.
 //!
 //! - Compiler-Base-Error provides `DiagnosticHandler` to diaplay diagnostic.
-//! For more information about `DiagnosticHandler`, see doc in 'compiler_base/error/diagnostic/diagnostic_handler.rs'.
+//!   For more information about `DiagnosticHandler`, see doc in 'compiler_base/error/diagnostic/diagnostic_handler.rs'.
 //!
 //! - TODO(zongz): Compiler-Base-Error provides `ErrorRecover` to recover from errors.
 
@@ -17,9 +17,9 @@ pub mod errors;
 pub mod unit_type;
 
 pub use diagnostic::{
-    components, diagnostic_handler, style::DiagnosticStyle, Component, Diagnostic, StyledBuffer,
-    StyledString,
+    Component, Diagnostic, StyledBuffer, StyledString, components, diagnostic_handler,
+    style::DiagnosticStyle,
 };
 
-pub use emitter::{emit_diagnostic_to_uncolored_text, Destination, Emitter, EmitterWriter};
+pub use emitter::{Destination, Emitter, EmitterWriter, emit_diagnostic_to_uncolored_text};
 pub use termcolor::{Ansi, Buffer, BufferWriter, ColorChoice, ColorSpec, StandardStream};

--- a/compiler_base/error/src/tests.rs
+++ b/compiler_base/error/src/tests.rs
@@ -2,8 +2,8 @@ mod test_diagnostic_handler {
     use std::panic;
 
     use crate::{
-        diagnostic_handler::{DiagnosticHandler, MessageArgs},
         Diagnostic, DiagnosticStyle,
+        diagnostic_handler::{DiagnosticHandler, MessageArgs},
     };
 
     #[test]
@@ -133,7 +133,10 @@ mod test_errors {
                 match err.downcast_ref::<ComponentError>() {
                     Some(ce) => {
                         let err_msg = format!("{:?}", ce);
-                        assert_eq!(err_msg, "ComponentFormatErrors([ComponentFormatError { name: \"ComponentGenError\", message: \"This is an error for testing\" }])")
+                        assert_eq!(
+                            err_msg,
+                            "ComponentFormatErrors([ComponentFormatError { name: \"ComponentGenError\", message: \"This is an error for testing\" }])"
+                        )
                     }
                     None => {
                         panic!("Error Type Error")
@@ -146,9 +149,8 @@ mod test_errors {
 
 mod test_emitter {
     use crate::{
-        components::Label, diagnostic_handler::DiagnosticHandler,
-        emit_diagnostic_to_uncolored_text, emitter::Destination, Diagnostic, Emitter,
-        EmitterWriter,
+        Diagnostic, Emitter, EmitterWriter, components::Label, emit_diagnostic_to_uncolored_text,
+        emitter::Destination,
     };
     use std::io::{self, Write};
     use termcolor::Ansi;

--- a/compiler_base/macros/Cargo.toml
+++ b/compiler_base/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compiler_base_macros"
 version = "0.1.1"
-edition = "2021"
+edition.workspace = true
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"
 description = "compiler_base_macros"

--- a/compiler_base/macros/src/tests.rs
+++ b/compiler_base/macros/src/tests.rs
@@ -39,7 +39,10 @@ mod test_bug {
                 } else {
                     panic!("test bug!() failed")
                 };
-                assert_eq!(err_message, "Internal error, please report a bug to us. The error message is: an error msg with string format msg");
+                assert_eq!(
+                    err_message,
+                    "Internal error, please report a bug to us. The error message is: an error msg with string format msg"
+                );
             }
         }
     }

--- a/compiler_base/parallel/Cargo.toml
+++ b/compiler_base/parallel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compiler_base_parallel"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"
 description = "A common domain programming language framework."

--- a/compiler_base/parallel/src/executor/mod.rs
+++ b/compiler_base/parallel/src/executor/mod.rs
@@ -1,10 +1,10 @@
 //! This file provides everything to define a [`Executor`] that can execute [`crate::task::Task`].
 use std::{
-    sync::{mpsc::Sender, Arc, Mutex},
+    sync::{Arc, Mutex, mpsc::Sender},
     thread::{self, JoinHandle},
 };
 
-use super::task::{event::TaskEvent, FinishedTask, Task};
+use super::task::{FinishedTask, Task, event::TaskEvent};
 use anyhow::Result;
 
 pub mod timeout;

--- a/compiler_base/parallel/src/executor/tests.rs
+++ b/compiler_base/parallel/src/executor/tests.rs
@@ -5,7 +5,7 @@ mod test_timeout_executor {
         io,
         io::Write,
         panic,
-        sync::{mpsc::channel, Arc, Mutex},
+        sync::{Arc, Mutex, mpsc::channel},
         thread,
         time::{Duration, Instant},
     };
@@ -14,14 +14,14 @@ mod test_timeout_executor {
     use rand::Rng;
 
     use crate::{
-        executor::{timeout::TimeoutExecutor, Executor},
+        executor::{Executor, timeout::TimeoutExecutor},
         task::{
+            FinishedTask, Task, TaskInfo, TaskStatus,
             event::TaskEvent,
             reporter::{
                 file_reporter_init, report_event, report_event_details, report_event_short_message,
                 std_reporter_init,
             },
-            FinishedTask, Task, TaskInfo, TaskStatus,
         },
     };
 
@@ -246,11 +246,10 @@ mod test_timeout_executor {
                 panic!("unreachable code");
             }
             Err(_) => {
-                assert_eq!(events_collector
-                            .lock()
-                            .unwrap()
-                            .events_str,
-                        "tname:PanicTask tid:0 event:waiting\ntname:PanicTask tid:0 event:timeout 59s\n");
+                assert_eq!(
+                    events_collector.lock().unwrap().events_str,
+                    "tname:PanicTask tid:0 event:waiting\ntname:PanicTask tid:0 event:timeout 59s\n"
+                );
                 handle.thread().unpark();
             }
         }

--- a/compiler_base/parallel/src/executor/timeout.rs
+++ b/compiler_base/parallel/src/executor/timeout.rs
@@ -2,16 +2,16 @@
 //! [`TimeoutExecutor`] is a [`Executor`] with a timeout queue that can monitor the timeout situation of [`Task`]s.
 use std::{
     collections::{HashMap, VecDeque},
-    sync::mpsc::{channel, RecvTimeoutError},
+    sync::mpsc::{RecvTimeoutError, channel},
     time::{Duration, Instant},
 };
 
 use crate::task::{
-    event::TaskEvent, FinishedTask, RunningTask, Task, TaskId, TaskInfo, TaskStatus,
+    FinishedTask, RunningTask, Task, TaskId, TaskInfo, TaskStatus, event::TaskEvent,
 };
 
-use super::{start_task, Executor};
-use anyhow::{bail, Result};
+use super::{Executor, start_task};
+use anyhow::{Result, bail};
 
 /// [`TimeoutSituation`] is an internal structure for the timeout situation of a [`Task`].
 pub(crate) struct TimeoutSituation {

--- a/compiler_base/parallel/src/task/mod.rs
+++ b/compiler_base/parallel/src/task/mod.rs
@@ -179,16 +179,16 @@ impl std::fmt::Display for TaskStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             TaskStatus::Finished => {
-                write!(f, "{}", "finished")
+                write!(f, "finished")
             }
             TaskStatus::Waiting => {
-                write!(f, "{}", "waiting")
+                write!(f, "waiting")
             }
             TaskStatus::Failed(reason) => {
-                write!(f, "{}:{}", "failed", reason)
+                write!(f, "failed:{}", reason)
             }
             TaskStatus::Bug(reason) => {
-                write!(f, "{}:{}", "bug", reason)
+                write!(f, "bug:{}", reason)
             }
         }
     }
@@ -292,13 +292,13 @@ impl RunningTask {
         if let Some(join_handle) = self.join_handle {
             // If [`Task`] returns [`TaskStatus::Finished`], that means [`Task`] is running correctly,
             // but the thread executing the [`Task`] returns an error, that means there's a bug.
-            if join_handle.join().is_err() {
-                if let TaskStatus::Finished = task.status() {
-                    task.find_bug(format!(
-                        "Exception occurs after task '{}' reporting success",
-                        task.tinfo()
-                    ));
-                }
+            if join_handle.join().is_err()
+                && let TaskStatus::Finished = task.status()
+            {
+                task.find_bug(format!(
+                    "Exception occurs after task '{}' reporting success",
+                    task.tinfo()
+                ));
             }
         }
     }
@@ -307,7 +307,7 @@ impl RunningTask {
 #[allow(unused)]
 mod test {
     use std::{
-        sync::mpsc::{channel, Sender},
+        sync::mpsc::{Sender, channel},
         thread,
     };
 

--- a/compiler_base/session/Cargo.toml
+++ b/compiler_base/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compiler_base_session"
 version = "0.1.3"
-edition = "2021"
+edition.workspace = true
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"
 description = "compiler_base_session"

--- a/compiler_base/session/src/lib.rs
+++ b/compiler_base/session/src/lib.rs
@@ -1,5 +1,7 @@
+#![allow(clippy::arc_with_non_send_sync)]
+
 use anyhow::{Context, Result};
-use compiler_base_error::{diagnostic_handler::DiagnosticHandler, Diagnostic, DiagnosticStyle};
+use compiler_base_error::{Diagnostic, DiagnosticStyle, diagnostic_handler::DiagnosticHandler};
 use compiler_base_span::{FilePathMapping, SourceMap};
 use std::{
     path::{Path, PathBuf},
@@ -93,7 +95,7 @@ impl Session {
                 sm.new_source_file(PathBuf::from(filename).into(), c.to_string());
             }
             None => {
-                sm.load_file(&Path::new(&filename))
+                sm.load_file(Path::new(&filename))
                     .with_context(|| "Failed to load source file")?;
             }
         }

--- a/compiler_base/session/src/tests.rs
+++ b/compiler_base/session/src/tests.rs
@@ -4,10 +4,10 @@ mod test_session {
     use crate::{Session, SessionDiagnostic};
     use anyhow::Result;
     use compiler_base_error::{
-        components::{CodeSnippet, Label},
         Diagnostic, DiagnosticStyle,
+        components::{CodeSnippet, Label},
     };
-    use compiler_base_span::{span::new_byte_pos, Span};
+    use compiler_base_span::{Span, span::new_byte_pos};
 
     const CARGO_ROOT: &str = env!("CARGO_MANIFEST_DIR");
     #[test]

--- a/compiler_base/span/Cargo.toml
+++ b/compiler_base/span/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compiler_base_span"
 version = "0.1.3"
-edition = "2021"
+edition.workspace = true
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"
 description = "compiler_base_span"

--- a/compiler_base/span/src/lib.rs
+++ b/compiler_base/span/src/lib.rs
@@ -9,7 +9,7 @@
 
 pub mod span;
 pub use rustc_span::fatal_error;
-pub use span::{BytePos, Span, SpanData, DUMMY_SP};
+pub use span::{BytePos, DUMMY_SP, Span, SpanData};
 
 pub type SourceMap = rustc_span::SourceMap;
 pub type SourceFile = rustc_span::SourceFile;

--- a/crates/parser/src/entry.rs
+++ b/crates/parser/src/entry.rs
@@ -71,7 +71,7 @@ impl Entries {
     }
 
     /// [`iter`] will return an iterator of [`Entry`] in [`Entries`].
-    pub fn iter(&self) -> std::collections::vec_deque::Iter<Entry> {
+    pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, Entry> {
         self.entries.iter()
     }
 

--- a/crates/runtime/src/value/val_dict.rs
+++ b/crates/runtime/src/value/val_dict.rs
@@ -34,7 +34,7 @@ impl DictValue {
 }
 
 impl ValueRef {
-    fn dict_config(&self) -> Ref<DictValue> {
+    fn dict_config(&self) -> Ref<'_, DictValue> {
         Ref::map(self.rc.borrow(), |val| match val {
             Value::dict_value(dict) => dict.as_ref(),
             Value::schema_value(schema) => schema.config.as_ref(),


### PR DESCRIPTION
chore: bump rust 1.91 and edition 2024 & fix all lint issues in compiler_base