### PR TITLE
fix: template exec yaml encode obj

### DIFF
--- a/crates/runtime/src/template/mod.rs
+++ b/crates/runtime/src/template/mod.rs
@@ -1,7 +1,33 @@
 use std::collections::HashMap;
 
 use crate::*;
-use handlebars::{Handlebars, html_escape};
+use handlebars::{
+    Context, Handlebars, Helper, HelperResult, Output, RenderContext, RenderErrorReason,
+    html_escape,
+};
+
+/// Custom helper that renders a value without HTML escaping.
+/// Usage: {{raw var}}
+fn raw_helper(
+    h: &Helper,
+    _: &Handlebars,
+    _: &Context,
+    _: &mut RenderContext,
+    out: &mut dyn Output,
+) -> HelperResult {
+    let param = h
+        .param(0)
+        .ok_or(RenderErrorReason::Other("Parameter not found".into()))?;
+    let value = param.value();
+
+    // Output the raw JSON value without HTML escaping
+    if let Some(s) = value.as_str() {
+        out.write(s)?;
+    } else {
+        out.write(&value.to_string())?;
+    }
+    Ok(())
+}
 
 /// Applies a parsed template to the specified data object and
 /// returns the string output.
@@ -19,6 +45,10 @@ pub unsafe extern "C-unwind" fn kcl_template_execute(
 
     if let Some(template) = get_call_arg_str(args, kwargs, 0, Some("template")) {
         let mut handlebars = Handlebars::new();
+
+        // Register helper for raw (unescaped) output
+        handlebars.register_helper("raw", Box::new(raw_helper));
+
         handlebars
             .register_template_string("template", template)
             .expect("register template failed");
@@ -53,5 +83,140 @@ pub unsafe extern "C-unwind" fn kcl_template_html_escape(
     if let Some(data) = get_call_arg_str(args, kwargs, 0, Some("data")) {
         return ValueRef::str(&html_escape(&data)).into_raw(ctx);
     }
-    panic!("html_escape() takes exactly one argument (0 given)");
+    panic!("html_escape() takes exactly one argument (0 given)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_raw_helper_with_html() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("raw", Box::new(raw_helper));
+
+        let template = r#"{{raw value}}"#.to_string();
+        handlebars
+            .register_template_string("test", template)
+            .expect("register template failed");
+
+        let mut data = serde_json::map::Map::new();
+        data.insert(
+            "value".to_string(),
+            serde_json::Value::String("<div>test</div>".to_string()),
+        );
+
+        let result = handlebars.render("test", &data).expect("render failed");
+        assert_eq!(result, "<div>test</div>");
+    }
+
+    #[test]
+    fn test_raw_helper_with_quotes() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("raw", Box::new(raw_helper));
+
+        let template = r#"{{raw value}}"#.to_string();
+        handlebars
+            .register_template_string("test", template)
+            .expect("register template failed");
+
+        let mut data = serde_json::map::Map::new();
+        data.insert(
+            "value".to_string(),
+            serde_json::Value::String(r#"timeout: "5m""#.to_string()),
+        );
+
+        let result = handlebars.render("test", &data).expect("render failed");
+        assert_eq!(result, r#"timeout: "5m""#);
+    }
+
+    #[test]
+    fn test_raw_helper_with_yaml_like_content() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("raw", Box::new(raw_helper));
+
+        let template = r#"{{raw value}}"#.to_string();
+        handlebars
+            .register_template_string("test", template)
+            .expect("register template failed");
+
+        let yaml_content = r#"config:
+  timeout: "5m""#;
+        let mut data = serde_json::map::Map::new();
+        data.insert(
+            "value".to_string(),
+            serde_json::Value::String(yaml_content.to_string()),
+        );
+
+        let result = handlebars.render("test", &data).expect("render failed");
+        assert_eq!(result, yaml_content);
+    }
+
+    #[test]
+    fn test_normal_template_still_escapes() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("raw", Box::new(raw_helper));
+
+        // Test that normal {{var}} still escapes
+        let template = r#"{{value}}"#.to_string();
+        handlebars
+            .register_template_string("test", template)
+            .expect("register template failed");
+
+        let mut data = serde_json::map::Map::new();
+        data.insert(
+            "value".to_string(),
+            serde_json::Value::String("<div>test</div>".to_string()),
+        );
+
+        let result = handlebars.render("test", &data).expect("render failed");
+        // Normal syntax should escape
+        assert_eq!(result, "&lt;div&gt;test&lt;/div&gt;");
+    }
+
+    #[test]
+    fn test_triple_brace_syntax() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("raw", Box::new(raw_helper));
+
+        // Test standard Handlebars triple brace syntax
+        let template = r#"{{{value}}}"#.to_string();
+        handlebars
+            .register_template_string("test", template)
+            .expect("register template failed");
+
+        let mut data = serde_json::map::Map::new();
+        data.insert(
+            "value".to_string(),
+            serde_json::Value::String("<div>test</div>".to_string()),
+        );
+
+        let result = handlebars.render("test", &data).expect("render failed");
+        // Triple braces should not escape
+        assert_eq!(result, "<div>test</div>");
+    }
+
+    #[test]
+    fn test_raw_vs_normal_syntax() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("raw", Box::new(raw_helper));
+
+        let template = r#"normal: {{value}}, raw: {{raw value}}, triple: {{{value}}}"#.to_string();
+        handlebars
+            .register_template_string("test", template)
+            .expect("register template failed");
+
+        let mut data = serde_json::map::Map::new();
+        data.insert(
+            "value".to_string(),
+            serde_json::Value::String(r#""test""#.to_string()),
+        );
+
+        let result = handlebars.render("test", &data).expect("render failed");
+        // normal should escape quotes to &quot;, raw and triple should not
+        assert_eq!(
+            result,
+            r#"normal: &quot;test&quot;, raw: "test", triple: "test""#
+        );
+    }
 }

--- a/tests/grammar/builtins/template/html_escape_preserved_0/main.k
+++ b/tests/grammar/builtins/template/html_escape_preserved_0/main.k
@@ -1,0 +1,4 @@
+import template
+
+# Verify that normal template still escapes HTML (backward compatibility)
+content = template.execute("""{{value}}""", {value = "<div>test</div>"})

--- a/tests/grammar/builtins/template/html_escape_preserved_0/stdout.golden
+++ b/tests/grammar/builtins/template/html_escape_preserved_0/stdout.golden
@@ -1,0 +1,1 @@
+content: '&lt;div&gt;test&lt;/div&gt;'

--- a/tests/grammar/builtins/template/raw_comparison_0/main.k
+++ b/tests/grammar/builtins/template/raw_comparison_0/main.k
@@ -1,0 +1,6 @@
+import template
+
+# Test comparison: normal {{var}} vs {{raw var}}
+escaped = template.execute("""{{value}}""", {value = "<div>test</div>"})
+unescaped = template.execute("""{{raw value}}""", {value = "<div>test</div>"})
+unescaped_triple = template.execute("""{{{value}}}""", {value = "<div>test</div>"})

--- a/tests/grammar/builtins/template/raw_comparison_0/stdout.golden
+++ b/tests/grammar/builtins/template/raw_comparison_0/stdout.golden
@@ -1,0 +1,3 @@
+escaped: '&lt;div&gt;test&lt;/div&gt;'
+unescaped: <div>test</div>
+unescaped_triple: <div>test</div>

--- a/tests/grammar/builtins/template/raw_helper_0/stdout.golden
+++ b/tests/grammar/builtins/template/raw_helper_0/stdout.golden
@@ -1,0 +1,1 @@
+content: '<div>test</div>'

--- a/tests/grammar/builtins/template/raw_multiline_0/main.k
+++ b/tests/grammar/builtins/template/raw_multiline_0/main.k
@@ -1,0 +1,13 @@
+import yaml
+import template
+
+# Test raw helper with multiline YAML content
+content = template.execute("""{{raw value}}""", {value = yaml.encode(_val)})
+
+_val = {
+    name = "test"
+    config = {
+        timeout = "5m"
+        retry = 3
+    }
+}

--- a/tests/grammar/builtins/template/raw_multiline_0/stdout.golden
+++ b/tests/grammar/builtins/template/raw_multiline_0/stdout.golden
@@ -1,0 +1,5 @@
+content: |
+  name: test
+  config:
+    timeout: '5m'
+    retry: 3

--- a/tests/grammar/builtins/template/raw_quotes_0/main.k
+++ b/tests/grammar/builtins/template/raw_quotes_0/main.k
@@ -1,0 +1,4 @@
+import template
+
+# Test that raw helper preserves quotes
+content = template.execute("""{{raw value}}""", {value = "value: \"test\""})

--- a/tests/grammar/builtins/template/raw_quotes_0/stdout.golden
+++ b/tests/grammar/builtins/template/raw_quotes_0/stdout.golden
@@ -1,0 +1,1 @@
+content: 'value: "test"'

--- a/tests/grammar/builtins/template/raw_yaml_0/stdout.golden
+++ b/tests/grammar/builtins/template/raw_yaml_0/stdout.golden
@@ -1,0 +1,4 @@
+test:
+  key: |
+    config:
+      timeout: '5m'

--- a/tests/grammar/builtins/template/triple_brace_0/stdout.golden
+++ b/tests/grammar/builtins/template/triple_brace_0/stdout.golden
@@ -1,0 +1,4 @@
+test:
+  key: |
+    config:
+      timeout: '5m'


### PR DESCRIPTION
fix: template exec yaml encode obj

closes #1976 
