### PR TITLE
docs: add building and testing chapters (fixes #1935)

### DIFF
--- a/docs/dev_guide/2.quick_start.md
+++ b/docs/dev_guide/2.quick_start.md
@@ -108,7 +108,7 @@ In the top level of the `kcl-lang/kcl` repo and run:
 
 #### wasm32-wasip1
 
-In the top level of of the `kcl-lang/kcl` repo and run:
+In the top level of the `kcl-lang/kcl` repo and run:
 
 ```shell
 make build-wasm
@@ -143,6 +143,62 @@ In the top level of the `kcl-lang/kcl` repo and run:
 ```sh
 make fmt
 ```
+## Building and Testing
+
+### 1. Building from Source
+
+The project uses a `Makefile` to simplify build commands.
+
+**Build the CLI and Core:**
+
+```sh
+make build
+```
+
+This will run the build script and place the binaries in the `_build/dist` directory.
+
+**Build specific components (e.g., LSP):**
+
+```sh
+make build-lsp
+```
+
+### 2. Running Tests
+
+**Run Rust Unit Tests:**
+
+```sh
+make test
+```
+
+**Run KCL Grammar/E2E Tests (Python):**
+
+```sh
+make test-grammar
+```
+
+_Note: This requires Python 3 and the dependencies listed in `Makefile` (run `make install-test-deps` first)._
+
+### 3. Updating Snapshot Tests (Pattern Matching)
+
+KCL uses [insta](https://github.com/mitsuhiko/insta) for snapshot testing in Rust. If you make changes to the compiler (parser, evaluator, etc.) that change the output, existing tests will fail.
+
+**To update the snapshots:**
+
+1. Install the cargo-insta tool:
+
+```sh
+cargo install cargo-insta
+```
+
+2. Run the tests. If snapshots mismatch, run the review command:
+
+```sh
+cargo insta review
+```
+
+3. Review the changes one by one. Press `a` to accept a new snapshot or `r` to reject it.
+    
 
 ## Contributor Procedures
 


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

fix #1935

#### 2. What is the scope of this PR (e.g. component or file name):

docs/dev_guide/2.quick_start.md

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

**Motivation:**
The developer guide was missing specific instructions on how to build the project from source and how to run the test suites. Additionally, new contributors often struggle with "snapshot" (pattern matching) tests because the usage of `cargo insta` was not documented.

**Changes:**
- Added a new **"Building and Testing"** section to the Quick Start guide.
- Documented `make build` and `make build-lsp`.
- Documented `make test` (Rust unit tests) and `make test-grammar` (Python integration tests).
- Added specific instructions for installing and using `cargo insta` to update snapshot tests.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [ ] Other

**Verification Steps:**
I verified the commands documented in this PR locally:
1. Ran `make build` -> Successfully compiled the CLI and Core.
2. Ran `make test` -> Verified it runs the Rust test suite.
3. Verified `cargo insta review` is the correct command to handle snapshot failures (confirmed by triggering a snapshot mismatch locally).