### PR TITLE
feat(format): format lambda signatures based on line length

### DIFF
--- a/crates/ast_pretty/src/lib.rs
+++ b/crates/ast_pretty/src/lib.rs
@@ -62,6 +62,8 @@ pub trait PrinterHook {
 pub struct Printer<'p> {
     /// Output string buffer.
     pub out: String,
+    /// Temporary buffers for look ahead formatting
+    pub tmp_buffers: Vec<String>,
     pub indent: usize,
     pub cfg: Config,
     /// Print comments,
@@ -79,6 +81,7 @@ impl Default for Printer<'_> {
         Self {
             hook: &NoHook,
             out: Default::default(),
+            tmp_buffers: Vec::default(),
             indent: Default::default(),
             cfg: Default::default(),
             comments: Default::default(),
@@ -93,6 +96,7 @@ impl<'p> Printer<'p> {
     pub fn new(cfg: Config, hook: &'p (dyn PrinterHook + 'p)) -> Self {
         Self {
             out: "".to_string(),
+            tmp_buffers: Vec::default(),
             indent: 0,
             cfg,
             comments: VecDeque::default(),
@@ -143,7 +147,10 @@ impl<'p> Printer<'p> {
     /// Print string
     #[inline]
     pub fn write_string(&mut self, string: &str) {
-        self.out.push_str(string);
+        self.tmp_buffers
+            .last_mut()
+            .unwrap_or(&mut self.out)
+            .push_str(string);
     }
 
     pub fn write_indentation(&mut self, indentation: Indentation) {
@@ -316,6 +323,14 @@ impl<'p> Printer<'p> {
     /// Leave with a dedent
     pub fn leave(&mut self) {
         self.indent -= 1;
+    }
+
+    pub(crate) fn push_tmp_buffer(&mut self) {
+        self.tmp_buffers.push(String::new());
+    }
+
+    pub(crate) fn pop_tmp_buffer(&mut self) -> Option<String> {
+        self.tmp_buffers.pop()
     }
 
     pub(crate) fn push_expr_span(&mut self, start_line: u64, end_line: u64) {

--- a/crates/ast_pretty/src/node.rs
+++ b/crates/ast_pretty/src/node.rs
@@ -16,6 +16,7 @@ type ParameterType<'a> = (
 
 const COMMA_WHITESPACE: &str = ", ";
 const IDENTIFIER_REGEX: &str = r#"^\$?[a-zA-Z_]\w*$"#;
+const RECOMMENDED_LINE_LENGTH: usize = 80;
 
 macro_rules! interleave {
     ($inter: expr, $f: expr, $seq: expr) => {
@@ -707,19 +708,27 @@ impl<'p, 'ctx> MutSelfTypedResultWalker<'ctx> for Printer<'p> {
     }
 
     fn walk_lambda_expr(&mut self, lambda_expr: &'ctx ast::LambdaExpr) -> Self::Result {
-        self.write("lambda");
-        if let Some(args) = &lambda_expr.args {
-            self.write_space();
-            self.walk_arguments(&args.node);
+        let has_comments = lambda_expr
+            .args
+            .as_ref()
+            .map(|args| args.node.args.iter().any(|e| self.has_comments_on_node(e)))
+            .unwrap_or(false);
+        let multiline = has_comments || {
+            self.push_tmp_buffer();
+            self.write_single_line_lambda_signature(lambda_expr);
+            let line_length = self.pop_tmp_buffer().map_or(0, |buf| buf.len());
+            line_length > RECOMMENDED_LINE_LENGTH
+        };
+
+        if multiline {
+            self.write_multi_line_lambda_signature(lambda_expr);
+        } else {
+            self.write_single_line_lambda_signature(lambda_expr);
         }
-        if let Some(ty_str) = &lambda_expr.return_ty {
-            self.write_space();
-            self.write_token(TokenKind::RArrow);
-            self.write_space();
-            self.write(&ty_str.node.to_string());
-        }
+
         self.write_space();
         self.write_token(TokenKind::OpenDelim(DelimToken::Brace));
+
         self.write_newline_without_fill();
         self.write_indentation(Indentation::Indent);
 
@@ -954,6 +963,77 @@ impl<'p> Printer<'p> {
         } else {
             self.write(&attr.node);
         };
+    }
+
+    fn write_single_line_lambda_signature(&mut self, lambda_expr: &ast::LambdaExpr) {
+        self.write("lambda");
+        if let Some(args) = &lambda_expr.args {
+            self.write_space();
+            self.walk_arguments(&args.node);
+        }
+        if let Some(ty_str) = &lambda_expr.return_ty {
+            self.write_space();
+            self.write_token(TokenKind::RArrow);
+            self.write_space();
+            self.write(&ty_str.node.to_string());
+        }
+    }
+
+    fn write_multi_line_lambda_signature(&mut self, lambda_expr: &ast::LambdaExpr) {
+        self.write("lambda");
+        self.write_space();
+        self.write_token(TokenKind::OpenDelim(DelimToken::Brace));
+        self.write_newline_without_fill();
+        self.write_indentation(Indentation::Indent);
+        self.fill("");
+
+        if let Some(args) = &lambda_expr.args {
+            let parameter_zip_list: Vec<ParameterType<'_>> = args
+                .node
+                .args
+                .iter()
+                .zip(
+                    args.node
+                        .ty_list
+                        .iter()
+                        .map(|ty| ty.clone().map(|n| n.node.to_string())),
+                )
+                .zip(args.node.defaults.iter())
+                .collect();
+            interleave!(
+                || {
+                    self.write(",");
+                    self.writeln("");
+                },
+                |para: &ParameterType<'_>| {
+                    let ((arg, ty_str), default) = para;
+                    self.write_comments_before_node(arg);
+                    self.walk_identifier(&arg.node);
+                    if let Some(ty_str) = ty_str {
+                        self.write(&format!(": {}", ty_str));
+                    }
+                    if let Some(default) = default {
+                        self.write(" = ");
+                        self.expr(default);
+                    }
+                },
+                parameter_zip_list
+            );
+        }
+
+        self.write(",");
+        self.write_newline_without_fill();
+        self.write_indentation(Indentation::Dedent);
+        self.fill("");
+        self.write_token(TokenKind::CloseDelim(DelimToken::Brace));
+        self.write_space();
+        self.write_token(TokenKind::RArrow);
+        self.write_space();
+        if let Some(ty_str) = &lambda_expr.return_ty {
+            self.write(&ty_str.node.to_string());
+        } else {
+            self.write("any");
+        }
     }
 }
 

--- a/crates/tools/src/format/test_data/format_data/lambda.golden
+++ b/crates/tools/src/format/test_data/format_data/lambda.golden
@@ -11,3 +11,47 @@ f2 = lambda {
         }
     }
 }
+f3 = lambda {
+    x,
+    y: int = 3,
+    z,
+    some_super_long_argument: SomeSuperLongType,
+    another_super_long_arguments: YetAnotherSuperLongTypeThatTakesQuiteAFewCharacters,
+} -> any {
+    y + x + z + 1
+}
+f4 = lambda {
+    x,
+    y: int = 3,
+    z,
+    some_super_long_argument: SomeSuperLongType,
+    another_super_long_arguments: YetAnotherSuperLongTypeThatTakesQuiteAFewCharacters,
+} -> any {
+    y + x + z + 1
+}
+f5 = lambda x: any = {y = 1} -> any {
+    y + x + z + 1
+}
+f6 = lambda {
+    # some comment
+    x,
+    # some other comment
+    y,
+} -> any {
+    y + x + z + 1
+}
+f7 = lambda {
+    # some comment
+    x: int = 5,
+} -> any {
+    1
+}
+f8 = lambda {
+    x: any = {
+        some_very_long_key_that_takes_a_long_line = 1
+        another_very_long_key_that_takes_a_long_line = 1
+        x = 2
+    },
+} -> any {
+    5
+}

--- a/crates/tools/src/format/test_data/format_data/lambda.input
+++ b/crates/tools/src/format/test_data/format_data/lambda.input
@@ -11,3 +11,29 @@ f2 = lambda {
         }
     }
 }
+f3 = lambda {x, y   :int    = 3, z, some_super_long_argument: SomeSuperLongType, another_super_long_arguments: YetAnotherSuperLongTypeThatTakesQuiteAFewCharacters} -> any {
+           y    +   x + z +    1
+}
+f4 = lambda x, y   :int    = 3, z, some_super_long_argument: SomeSuperLongType, another_super_long_arguments: YetAnotherSuperLongTypeThatTakesQuiteAFewCharacters {
+           y    +   x + z +    1
+}
+f5 = lambda x: any = {                                                                     y = 1 } -> any {
+           y    +   x + z +    1
+}
+f6 = lambda {
+   x, # some comment
+   y  # some other comment
+} -> any {
+           y    +   x + z +    1
+}
+f7 = lambda {
+   x: int = 5, # some comment
+} -> any {
+     1
+}
+f8 = lambda x: any = {
+    some_very_long_key_that_takes_a_long_line = 1
+    another_very_long_key_that_takes_a_long_line = 1, x = 2
+} {
+           5
+}


### PR DESCRIPTION


#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y

Fixes #1941

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

Code formatter.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

Will format lambda arguments on individual lines based on overall formatted line length or if the arguments contain comments.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

Not sure how one would argue here. Existing programs might be formatted differently. If users have format checks, these might fail.

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
