### PR TITLE
perf(ast): use monotonic counter for AstIndex instead of Uuid::new_v4

### DIFF
--- a/crates/ast/Cargo.toml
+++ b/crates/ast/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uuid = { version = "1.4.1", features = ["v4"] }
+uuid = { version = "1.4.1" }
 compiler_base_span.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/ast/src/ast.rs
+++ b/crates/ast/src/ast.rs
@@ -43,6 +43,7 @@ use std::{
 use compiler_base_span::{Loc, Span};
 use std::fmt::Debug;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use uuid;
 
 use super::token;
@@ -109,9 +110,13 @@ impl Serialize for AstIndex {
     }
 }
 
+static AST_INDEX_COUNTER: AtomicU64 = AtomicU64::new(1);
+
 impl Default for AstIndex {
     fn default() -> Self {
-        Self(uuid::Uuid::new_v4())
+        Self(uuid::Uuid::from_u128(
+            AST_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed) as u128,
+        ))
     }
 }
 


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?

- [x] N

#### 2. What is the scope of this PR

`AstIndex::default()` in `crates/ast`.

#### 3. Provide a description of the PR

- [x] Other

Every AST node calls `Uuid::new_v4()`, which hits the OS RNG. Node ids only need to be unique within a process and are never read back from serialized data (`skip_deserializing`), so a monotonic counter works just as well and keeps the type and serialized form unchanged. Also drops the now-unused `uuid` v4 feature.

#### 4. Are there any breaking changes?

- [x] N

#### 5. Are there test cases for these changes?

- [x] Benchmark

`bench_runner` wall time:

| | ms |
|---|---|
| `Uuid::new_v4` | 30.9 |
| atomic counter | 27.7 |