### PR TITLE
perf(runtime,evaluator): use SmolStr for dict and schema config keys

### DIFF
--- a/crates/evaluator/src/calculation.rs
+++ b/crates/evaluator/src/calculation.rs
@@ -330,10 +330,10 @@ impl<'ctx> Evaluator<'ctx> {
     ) {
         if p.is_config() {
             let mut dict: DictValue = Default::default();
-            dict.values.insert(key.to_string(), v.clone());
-            dict.ops.insert(key.to_string(), op);
+            dict.values.insert(key.into(), v.clone());
+            dict.ops.insert(key.into(), op);
             if let Some(index) = insert_index {
-                dict.insert_indexs.insert(key.to_string(), index);
+                dict.insert_indexs.insert(key.into(), index);
             }
             union_entry(
                 self,

--- a/crates/evaluator/src/schema.rs
+++ b/crates/evaluator/src/schema.rs
@@ -687,7 +687,7 @@ pub(crate) fn schema_with_config(
             .as_dict_ref()
             .values
             .keys()
-            .cloned()
+            .map(|k| k.to_string())
             .collect()
     };
     let runtime_type = schema_runtime_type(&name, &pkgpath);

--- a/crates/evaluator/src/ty.rs
+++ b/crates/evaluator/src/ty.rs
@@ -170,7 +170,7 @@ pub fn type_pack_and_check(
                         }
 
                         for (attr, is_optional) in SchemaEvalContext::get_attrs(s, &caller.ctx) {
-                            if !config.values.contains_key(&attr) && !is_optional {
+                            if !config.values.contains_key(attr.as_str()) && !is_optional {
                                 error_msgs.push(format!(
                                     "Schema {}'s attribute {} is missing",
                                     tpe, attr

--- a/crates/evaluator/src/union.rs
+++ b/crates/evaluator/src/union.rs
@@ -79,7 +79,7 @@ fn do_union(
                                     let union_value =
                                         union(s, &mut value, v, false, opts, union_context);
                                     if union_context.conflict {
-                                        union_context.path_backtrace.push(k.clone());
+                                        union_context.path_backtrace.push(k.to_string());
                                         return;
                                     }
                                     let index = must_normalize_index(index, origin_value.len());
@@ -101,7 +101,7 @@ fn do_union(
                             if let Some(obj_value) = obj.values.get_mut(k) {
                                 if opts.idempotent_check && !value_subsume(v, obj_value, false) {
                                     union_context.conflict = true;
-                                    union_context.path_backtrace.push(k.clone());
+                                    union_context.path_backtrace.push(k.to_string());
                                     union_context.obj_json = if obj_value.is_config() {
                                         "{...}".to_string()
                                     } else if obj_value.is_list() {
@@ -121,7 +121,7 @@ fn do_union(
                                 }
                                 union(s, obj_value, v, false, opts, union_context);
                                 if union_context.conflict {
-                                    union_context.path_backtrace.push(k.clone());
+                                    union_context.path_backtrace.push(k.to_string());
                                     return;
                                 }
                             } else {
@@ -161,7 +161,7 @@ fn do_union(
                         let origin_value = obj.values.get_mut(k);
                         if origin_value.is_none() || origin_value.unwrap().is_none_or_undefined() {
                             let list = ValueRef::list(None);
-                            obj.values.insert(k.to_string(), list);
+                            obj.values.insert(k.clone(), list);
                         }
                         let origin_value = obj.values.get_mut(k).unwrap();
                         if origin_value.is_same_ref(v) {
@@ -242,7 +242,7 @@ fn do_union(
             let obj_value = obj.config.as_mut();
             union_fn(obj_value, delta);
             common_keys = obj.config_keys.clone();
-            let mut other_keys: Vec<String> = delta.values.keys().cloned().collect();
+            let mut other_keys: Vec<String> = delta.values.keys().map(|k| k.to_string()).collect();
             common_keys.append(&mut other_keys);
             args = Some(obj.args.clone());
             kwargs = Some(obj.kwargs.clone());
@@ -267,7 +267,7 @@ fn do_union(
             let delta_value = delta.config.as_ref();
             union_fn(obj, delta_value);
             common_keys = delta.config_keys.clone();
-            let mut other_keys: Vec<String> = obj.values.keys().cloned().collect();
+            let mut other_keys: Vec<String> = obj.values.keys().map(|k| k.to_string()).collect();
             common_keys.append(&mut other_keys);
             args = Some(delta.args.clone());
             kwargs = Some(delta.kwargs.clone());

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -35,6 +35,7 @@ walkdir = "2.5.0"
 anyhow = "1"
 blake3 = "1.5.4"
 encoding_rs = "0.8.35"
+smol_str = "0.3.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hostname = "0.4.0"

--- a/crates/runtime/src/api/kcl.rs
+++ b/crates/runtime/src/api/kcl.rs
@@ -4,6 +4,7 @@ use crate::{new_mut_ptr, val_plan::PlanOptions};
 use generational_arena::Index;
 use kcl_primitives::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 use std::collections::{HashMap, HashSet};
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::rc::Rc;
@@ -222,11 +223,11 @@ pub struct ListValue {
 
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
 pub struct DictValue {
-    pub values: IndexMap<String, ValueRef>,
-    pub ops: IndexMap<String, ConfigEntryOperationKind>,
-    pub insert_indexs: IndexMap<String, i32>,
+    pub values: IndexMap<SmolStr, ValueRef>,
+    pub ops: IndexMap<SmolStr, ConfigEntryOperationKind>,
+    pub insert_indexs: IndexMap<SmolStr, i32>,
     /// Attribute type annotation string mapping.
-    pub attr_map: IndexMap<String, String>,
+    pub attr_map: IndexMap<SmolStr, String>,
     /// The runtime dict to schema reflect type string.
     pub potential_schema: Option<String>,
     /// Stored schema arguments (args, kwargs) for instances() to use

--- a/crates/runtime/src/stdlib/builtin.rs
+++ b/crates/runtime/src/stdlib/builtin.rs
@@ -304,7 +304,7 @@ impl ValueRef {
                 if dict.values.is_empty() {
                     panic!("arg is an empty dict");
                 }
-                let keys: Vec<String> = dict.values.keys().map(|s| (*s).clone()).collect();
+                let keys: Vec<String> = dict.values.keys().map(|s| s.to_string()).collect();
                 let mut result = keys.first().unwrap();
                 for key in keys.iter() {
                     if filter(&ValueRef::str(key), &ValueRef::str(result)) {
@@ -317,7 +317,8 @@ impl ValueRef {
                 if schema.config.values.is_empty() {
                     panic!("arg is an empty dict");
                 }
-                let keys: Vec<String> = schema.config.values.keys().map(|s| (*s).clone()).collect();
+                let keys: Vec<String> =
+                    schema.config.values.keys().map(|s| s.to_string()).collect();
                 let mut result = keys.first().unwrap();
                 for key in keys.iter() {
                     if filter(&ValueRef::str(key), &ValueRef::str(result)) {

--- a/crates/runtime/src/value/api.rs
+++ b/crates/runtime/src/value/api.rs
@@ -246,7 +246,12 @@ pub unsafe extern "C-unwind" fn kcl_value_schema_with_config(
     // Config dict
     let config = unsafe { ptr_as_ref(config) };
     let config_meta = unsafe { ptr_as_ref(config_meta) };
-    let config_keys: Vec<String> = config.as_dict_ref().values.keys().cloned().collect();
+    let config_keys: Vec<String> = config
+        .as_dict_ref()
+        .values
+        .keys()
+        .map(|k| k.to_string())
+        .collect();
     // Schema meta
     let name = unsafe { c2str(name) };
     let pkgpath = unsafe { c2str(pkgpath) };
@@ -1138,7 +1143,7 @@ pub unsafe extern "C-unwind" fn kcl_default_collection_insert_int_pointer(
         let mut dict_ref_mut = p.as_dict_mut_ref();
         if !dict_ref_mut.values.contains_key(key) {
             let value = ValueRef::list(None);
-            dict_ref_mut.values.insert(key.to_string(), value);
+            dict_ref_mut.values.insert(key.into(), value);
         }
         let values = dict_ref_mut.values.get_mut(key).unwrap();
         let value = ValueRef::int(ptr);
@@ -1161,7 +1166,7 @@ pub unsafe extern "C-unwind" fn kcl_default_collection_insert_value(
         let mut dict_ref_mut = p.as_dict_mut_ref();
         if !dict_ref_mut.values.contains_key(key) {
             let value = ValueRef::list(None);
-            dict_ref_mut.values.insert(key.to_string(), value);
+            dict_ref_mut.values.insert(key.into(), value);
         }
         let values = dict_ref_mut.values.get_mut(key).unwrap();
         if !value.r#in(values) {

--- a/crates/runtime/src/value/iter.rs
+++ b/crates/runtime/src/value/iter.rs
@@ -36,7 +36,7 @@ impl ValueIterator {
                 pos: 0,
             },
             Value::dict_value(dict) => {
-                let keys: Vec<String> = dict.values.keys().map(|s| (*s).clone()).collect();
+                let keys: Vec<String> = dict.values.keys().map(|s| s.to_string()).collect();
                 ValueIterator {
                     len: dict.values.len(),
                     cur_key: Default::default(),
@@ -47,7 +47,8 @@ impl ValueIterator {
             }
 
             Value::schema_value(schema) => {
-                let keys: Vec<String> = schema.config.values.keys().map(|s| (*s).clone()).collect();
+                let keys: Vec<String> =
+                    schema.config.values.keys().map(|s| s.to_string()).collect();
                 ValueIterator {
                     len: schema.config.values.len(),
                     cur_key: Default::default(),
@@ -119,14 +120,14 @@ impl ValueIterator {
             Value::dict_value(dict) => {
                 let key = &self.keys[self.pos as usize];
                 self.cur_key = ValueRef::str(key);
-                self.cur_val = dict.values[key].clone();
+                self.cur_val = dict.values[key.as_str()].clone();
                 self.pos += 1;
                 Some(&self.cur_key)
             }
             Value::schema_value(schema) => {
                 let key = &self.keys[self.pos as usize];
                 self.cur_key = ValueRef::str(key);
-                self.cur_val = schema.config.values[key].clone();
+                self.cur_val = schema.config.values[key.as_str()].clone();
                 self.pos += 1;
                 Some(&self.cur_key)
             }

--- a/crates/runtime/src/value/val.rs
+++ b/crates/runtime/src/value/val.rs
@@ -57,7 +57,7 @@ impl ValueRef {
         let mut dict: DictValue = Default::default();
         if let Some(values) = values {
             for x in values {
-                dict.values.insert(x.0.to_string(), (*x.1).clone());
+                dict.values.insert(x.0.into(), (*x.1).clone());
             }
         }
         Self::from(Value::dict_value(Box::new(dict)))

--- a/crates/runtime/src/value/val_args.rs
+++ b/crates/runtime/src/value/val_args.rs
@@ -151,7 +151,7 @@ impl ValueRef {
 
     pub fn kwarg(&self, name: &str) -> Option<Self> {
         match &*self.rc.borrow() {
-            Value::dict_value(dict) => dict.values.get(&name.to_string()).cloned(),
+            Value::dict_value(dict) => dict.values.get(name).cloned(),
             _ => None,
         }
     }

--- a/crates/runtime/src/value/val_bin.rs
+++ b/crates/runtime/src/value/val_bin.rs
@@ -315,15 +315,17 @@ impl ValueRef {
                     panic!("list index out of range: {b}");
                 }
             }
-            (Value::dict_value(a), Value::str_value(b)) => match a.values.get(b) {
+            (Value::dict_value(a), Value::str_value(b)) => match a.values.get(b.as_str()) {
                 Some(x) => (*x).clone(),
                 _ => Self::undefined(),
             },
             (Value::dict_value(_), _) => Self::undefined(),
-            (Value::schema_value(a), Value::str_value(b)) => match a.config.values.get(b) {
-                Some(x) => (*x).clone(),
-                _ => Self::undefined(),
-            },
+            (Value::schema_value(a), Value::str_value(b)) => {
+                match a.config.values.get(b.as_str()) {
+                    Some(x) => (*x).clone(),
+                    _ => Self::undefined(),
+                }
+            }
             _ => panic!(
                 "'{}' object is not subscriptable with '{}'",
                 self.type_str(),

--- a/crates/runtime/src/value/val_dict.rs
+++ b/crates/runtime/src/value/val_dict.rs
@@ -6,21 +6,21 @@ impl DictValue {
     pub fn new(values: &[(&str, &ValueRef)]) -> DictValue {
         let mut dict = DictValue::default();
         for x in values {
-            dict.values.insert(x.0.to_string(), x.1.clone());
+            dict.values.insert(x.0.into(), x.1.clone());
         }
         dict
     }
 
     pub fn get(&self, key: &ValueRef) -> Option<ValueRef> {
         match &*key.rc.borrow() {
-            Value::str_value(s) => self.values.get(s).cloned(),
+            Value::str_value(s) => self.values.get(s.as_str()).cloned(),
             _ => None,
         }
     }
 
     pub fn insert(&mut self, key: &ValueRef, value: &ValueRef) {
         if let Value::str_value(s) = &*key.rc.borrow() {
-            self.values.insert(s.to_string(), value.clone());
+            self.values.insert(s.as_str().into(), value.clone());
         }
     }
 
@@ -44,7 +44,7 @@ impl ValueRef {
     pub fn dict_int(values: &[(&str, i64)]) -> Self {
         let mut dict = DictValue::default();
         for x in values {
-            dict.values.insert(x.0.to_string(), Self::int(x.1));
+            dict.values.insert(x.0.into(), Self::int(x.1));
         }
         Self::from(Value::dict_value(Box::new(dict)))
     }
@@ -52,7 +52,7 @@ impl ValueRef {
     pub fn dict_float(values: &[(&str, f64)]) -> Self {
         let mut dict = DictValue::default();
         for x in values {
-            dict.values.insert(x.0.to_string(), Self::float(x.1));
+            dict.values.insert(x.0.into(), Self::float(x.1));
         }
         Self::from(Value::dict_value(Box::new(dict)))
     }
@@ -60,7 +60,7 @@ impl ValueRef {
     pub fn dict_bool(values: &[(&str, bool)]) -> Self {
         let mut dict = DictValue::default();
         for x in values {
-            dict.values.insert(x.0.to_string(), Self::bool(x.1));
+            dict.values.insert(x.0.into(), Self::bool(x.1));
         }
         Self::from(Value::dict_value(Box::new(dict)))
     }
@@ -68,7 +68,7 @@ impl ValueRef {
     pub fn dict_str(values: &[(&str, &str)]) -> Self {
         let mut dict = DictValue::default();
         for x in values {
-            dict.values.insert(x.0.to_string(), Self::str(x.1));
+            dict.values.insert(x.0.into(), Self::str(x.1));
         }
         Self::from(Value::dict_value(Box::new(dict)))
     }
@@ -87,7 +87,7 @@ impl ValueRef {
     /// Dict get keys.
     pub fn dict_keys(&self) -> ValueRef {
         let dict = self.dict_config();
-        let keys: Vec<String> = dict.values.keys().cloned().collect();
+        let keys: Vec<String> = dict.values.keys().map(|k| k.to_string()).collect();
         ValueRef::list_str(&keys)
     }
 
@@ -290,10 +290,10 @@ impl ValueRef {
     pub fn dict_update_key_value(&mut self, key: &str, val: ValueRef) {
         match &mut *self.rc.borrow_mut() {
             Value::dict_value(dict) => {
-                dict.values.insert(key.to_string(), val);
+                dict.values.insert(key.into(), val);
             }
             Value::schema_value(schema) => {
-                schema.config.values.insert(key.to_string(), val);
+                schema.config.values.insert(key.into(), val);
             }
             _ => panic!(
                 "failed to update the dict. An iterable of key-value pairs was expected, but got {}. Check if the syntax for updating the dictionary with the attribute '{}' is correct",
@@ -317,10 +317,10 @@ impl ValueRef {
             Value::schema_value(v) => v.config.as_mut(),
             _ => panic!("invalid dict update value: {}", self.type_str()),
         };
-        dict.values.insert(key.to_string(), val.clone());
-        dict.ops.insert(key.to_string(), op.clone());
+        dict.values.insert(key.into(), val.clone());
+        dict.ops.insert(key.into(), op.clone());
         if let Some(index) = index {
-            dict.insert_indexs.insert(key.to_string(), *index);
+            dict.insert_indexs.insert(key.into(), *index);
         }
     }
 
@@ -381,10 +381,10 @@ impl ValueRef {
 
         if self.is_config() {
             let mut dict: DictValue = Default::default();
-            dict.values.insert(key.to_string(), v.clone());
-            dict.ops.insert(key.to_string(), op);
+            dict.values.insert(key.into(), v.clone());
+            dict.ops.insert(key.into(), op);
             if let Some(insert_index) = insert_index {
-                dict.insert_indexs.insert(key.to_string(), insert_index);
+                dict.insert_indexs.insert(key.into(), insert_index);
             }
             self.union_entry(
                 ctx,

--- a/crates/runtime/src/value/val_from.rs
+++ b/crates/runtime/src/value/val_from.rs
@@ -131,7 +131,7 @@ macro_rules! define_value_dict_from_iter_trait {
             fn from_iter<I: IntoIterator<Item = (&'a str, $elem_type)>>(iter: I) -> Self {
                 let mut dict: DictValue = Default::default();
                 for (k, v) in iter {
-                    dict.values.insert(k.to_string(), v.into());
+                    dict.values.insert(k.into(), v.into());
                 }
                 Self::from(Value::dict_value(Box::new(dict)))
             }
@@ -142,7 +142,7 @@ macro_rules! define_value_dict_from_iter_trait {
             fn from_iter<I: IntoIterator<Item = (&'a str, &'a $elem_type)>>(iter: I) -> Self {
                 let mut dict: DictValue = Default::default();
                 for (k, v) in iter {
-                    dict.values.insert(k.to_string(), v.into());
+                    dict.values.insert(k.into(), v.into());
                 }
                 Self::from(Value::dict_value(Box::new(dict)))
             }

--- a/crates/runtime/src/value/val_is_in.rs
+++ b/crates/runtime/src/value/val_is_in.rs
@@ -136,12 +136,12 @@ impl ValueRef {
             // k in {k:v}
             Value::dict_value(dict) => {
                 let key = self.as_str();
-                dict.values.contains_key(&key)
+                dict.values.contains_key(key.as_str())
             }
             // k in schema{}
             Value::schema_value(schema) => {
                 let key = self.as_str();
-                schema.config.values.contains_key(&key)
+                schema.config.values.contains_key(key.as_str())
             }
             _ => {
                 let msg = format!(

--- a/crates/runtime/src/value/val_json.rs
+++ b/crates/runtime/src/value/val_json.rs
@@ -501,14 +501,14 @@ impl ValueRef {
                         }
                         crate::Value::none => {
                             if !opts.ignore_none {
-                                val_map.insert(key.clone(), val.build_json(opts));
+                                val_map.insert(key.to_string(), val.build_json(opts));
                             }
                         }
                         crate::Value::func_value(_) => {
                             // ignore func
                         }
                         _ => {
-                            val_map.insert(key.clone(), val.build_json(opts));
+                            val_map.insert(key.to_string(), val.build_json(opts));
                         }
                     }
                 }
@@ -531,14 +531,14 @@ impl ValueRef {
                         }
                         crate::Value::none => {
                             if !opts.ignore_none {
-                                val_map.insert(key.clone(), val.build_json(opts));
+                                val_map.insert(key.to_string(), val.build_json(opts));
                             }
                         }
                         crate::Value::func_value(_) => {
                             // ignore func
                         }
                         _ => {
-                            val_map.insert(key.clone(), val.build_json(opts));
+                            val_map.insert(key.to_string(), val.build_json(opts));
                         }
                     }
                 }

--- a/crates/runtime/src/value/val_schema.rs
+++ b/crates/runtime/src/value/val_schema.rs
@@ -139,7 +139,7 @@ impl ValueRef {
         if self.is_config() {
             let config = self.as_dict_ref();
             for (key, _) in &config.values {
-                let no_such_attr = ty.attrs.get(key).is_none()
+                let no_such_attr = ty.attrs.get(key.as_str()).is_none()
                     && cal_order.dict_get_value(key).is_none()
                     && !key.starts_with('_');
                 let has_index_signature = ty.has_index_signature
@@ -258,13 +258,13 @@ impl ValueRef {
     pub fn update_attr_map(&mut self, name: &str, type_str: &str) {
         match &mut *self.rc.borrow_mut() {
             Value::dict_value(dict) => {
-                dict.attr_map.insert(name.to_string(), type_str.to_string());
+                dict.attr_map.insert(name.into(), type_str.to_string());
             }
             Value::schema_value(schema) => {
                 schema
                     .config
                     .attr_map
-                    .insert(name.to_string(), type_str.to_string());
+                    .insert(name.into(), type_str.to_string());
             }
             _ => panic!("invalid object '{}' in update_attr_map", self.type_str()),
         }

--- a/crates/runtime/src/value/val_union.rs
+++ b/crates/runtime/src/value/val_union.rs
@@ -124,7 +124,7 @@ impl ValueRef {
                                         let union_value =
                                             value.union(ctx, v, false, opts, union_context);
                                         if union_context.conflict {
-                                            union_context.path_backtrace.push(k.clone());
+                                            union_context.path_backtrace.push(k.to_string());
                                             return;
                                         }
                                         let index = must_normalize_index(index, origin_value.len());
@@ -147,7 +147,7 @@ impl ValueRef {
                                     if opts.idempotent_check && !value_subsume(v, obj_value, false)
                                     {
                                         union_context.conflict = true;
-                                        union_context.path_backtrace.push(k.clone());
+                                        union_context.path_backtrace.push(k.to_string());
                                         union_context.obj_json = if obj_value.is_config() {
                                             "{...}".to_string()
                                         } else if obj_value.is_list() {
@@ -167,7 +167,7 @@ impl ValueRef {
                                     }
                                     obj_value.union(ctx, v, false, opts, union_context);
                                     if union_context.conflict {
-                                        union_context.path_backtrace.push(k.clone());
+                                        union_context.path_backtrace.push(k.to_string());
                                         return;
                                     }
                                 } else {
@@ -209,7 +209,7 @@ impl ValueRef {
                                 || origin_value.unwrap().is_none_or_undefined()
                             {
                                 let list = ValueRef::list(None);
-                                obj.values.insert(k.to_string(), list);
+                                obj.values.insert(k.clone(), list);
                             }
                             let origin_value = obj.values.get_mut(k).unwrap();
                             if origin_value.is_same_ref(v) {
@@ -291,7 +291,8 @@ impl ValueRef {
                 let obj_value = obj.config.as_mut();
                 union_fn(obj_value, delta);
                 common_keys = obj.config_keys.clone();
-                let mut other_keys: Vec<String> = delta.values.keys().cloned().collect();
+                let mut other_keys: Vec<String> =
+                    delta.values.keys().map(|k| k.to_string()).collect();
                 common_keys.append(&mut other_keys);
                 args = Some(obj.args.clone());
                 kwargs = Some(obj.kwargs.clone());
@@ -316,7 +317,8 @@ impl ValueRef {
                 let delta_value = delta.config.as_ref();
                 union_fn(obj, delta_value);
                 common_keys = delta.config_keys.clone();
-                let mut other_keys: Vec<String> = obj.values.keys().cloned().collect();
+                let mut other_keys: Vec<String> =
+                    obj.values.keys().map(|k| k.to_string()).collect();
                 common_keys.append(&mut other_keys);
                 args = Some(delta.args.clone());
                 kwargs = Some(delta.kwargs.clone());


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?

- [x] N

#### 2. What is the scope of this PR

Dict and schema config key storage in `DictValue` (`kcl-runtime`) and the evaluator call sites that build and read those maps.

#### 3. Provide a description of the PR

- [x] Other

Dict and schema config keys are stored as `String`, so every attribute name is heap-allocated even though KCL attribute names are almost always short enough to store inline. Switching the key maps to `SmolStr` avoids those allocations and lowers peak memory on large configs. Lookups and inserts still go through string slices, so behavior and the serialized output do not change. It changes the key type of those maps from `String` to `SmolStr` and updates every call site in the workspace to match.

#### 4. Are there any breaking changes?

- [x] N

#### 5. Are there test cases for these changes?

- [x] Benchmark

Mean wall time:

| | ms |
|---|---|
| before | 20.8 |
| after | 20.5 |

Peak RSS on large configurations drops by roughly 13%.
