### PR TITLE
fix(evaluator): keep reassigned globals order-independent in lazy scope

### DIFF
--- a/crates/evaluator/src/lazy.rs
+++ b/crates/evaluator/src/lazy.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use generational_arena::Index;
 use kcl_ast::ast;
 use kcl_ast::ast::AstIndex;
-use kcl_primitives::IndexMap;
+use kcl_primitives::{IndexMap, IndexSet};
 use kcl_runtime::ValueRef;
 
 use crate::Evaluator;
@@ -51,6 +51,9 @@ pub struct LazyEvalScope {
     pub setters: IndexMap<String, Vec<Setter>>,
     /// Calculate times without backtracking.
     pub cal_times: IndexMap<String, usize>,
+    /// Keys whose cached value was resolved from a later setter via backtracking.
+    /// An earlier-precedence setter must not overwrite such a resolved entry.
+    pub resolved: IndexSet<String>,
 }
 
 impl LazyEvalScope {
@@ -367,6 +370,7 @@ impl<'ctx> Evaluator<'ctx> {
                                         lazy_scopes.get_mut(pkgpath).expect(INTERNAL_ERROR_MSG);
                                     scope.levels.insert(key.to_string(), level);
                                     scope.cache.insert(key.to_string(), value.clone());
+                                    scope.resolved.insert(key.to_string());
                                     value
                                 }
                             }
@@ -396,11 +400,22 @@ impl<'ctx> Evaluator<'ctx> {
     /// to avoid stale references in subsequent subscript assignments.
     #[inline]
     pub(crate) fn update_lazy_scope_cache(&self, pkgpath: &str, key: &str, value: &ValueRef) {
+        if !*self.lazy_reassign.borrow() {
+            return;
+        }
         let mut lazy_scopes = self.lazy_scopes.borrow_mut();
         if let Some(scope) = lazy_scopes.get_mut(pkgpath) {
-            // Always update the cache when a variable is reassigned, whether or not
-            // it already exists in the cache. This ensures subsequent loads get the
-            // new value instead of evaluating setters that would return a stale value.
+            // A value already resolved from a later setter via backtracking must not be
+            // downgraded by an earlier-precedence setter that the eager walk reaches
+            // afterwards (e.g. a base definition walked after a conditional override was
+            // resolved by an early reader). Only the last setter may refresh a resolved
+            // entry; forward in-place reassignments (|=, +=, subscript) were never
+            // backtrack-resolved, so they still update.
+            if scope.resolved.contains(key)
+                && !scope.is_last_setter_ast_index(key, &self.ast_id.borrow())
+            {
+                return;
+            }
             scope.cache.insert(key.to_string(), value.clone());
         }
     }

--- a/crates/evaluator/src/lib.rs
+++ b/crates/evaluator/src/lib.rs
@@ -87,6 +87,10 @@ pub struct Evaluator<'ctx> {
     pub scope_covers: RefCell<Vec<(usize, usize)>>,
     /// Local variables in the loop.
     pub local_vars: RefCell<HashSet<String>>,
+    /// True only while storing an augmented assignment (`+=`, `|=`, …) target, so
+    /// the lazy-scope cache is force-updated for in-place reassignment but not for a
+    /// plain `=` that would pre-empt backtracking to a later setter.
+    pub lazy_reassign: RefCell<bool>,
     /// Schema attr backtrack meta.
     pub backtrack_meta: RefCell<Vec<BacktrackMeta>>,
     /// Current AST id for the evaluator walker.
@@ -153,6 +157,7 @@ impl<'ctx> Evaluator<'ctx> {
             lazy_scopes: RefCell::new(Default::default()),
             scope_covers: RefCell::new(Default::default()),
             local_vars: RefCell::new(Default::default()),
+            lazy_reassign: RefCell::new(false),
             backtrack_meta: RefCell::new(Default::default()),
             ast_id: RefCell::new(AstIndex::default()),
             ctx_stack: RefCell::new(Default::default()),

--- a/crates/evaluator/src/node.rs
+++ b/crates/evaluator/src/node.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, RwLock};
 use anyhow::Ok;
 use generational_arena::Index;
 use kcl_ast::ast::{self, CallExpr, ConfigEntry, Module, NodeRef};
-use kcl_ast::walker::TypedResultWalker;
+use kcl_ast::walker::{MutSelfWalker, TypedResultWalker};
 use kcl_runtime::{
     ConfigEntryOperationKind, DecoratorValue, PKG_PATH_PREFIX, RuntimeErrorType, UnionOptions,
     ValueRef, schema_assert, schema_runtime_type,
@@ -26,6 +26,24 @@ use crate::ty::type_pack_and_check;
 use crate::union::union_entry;
 use crate::{EvalResult, Evaluator};
 use crate::{GLOBAL_LEVEL, INNER_LEVEL, error as kcl_error};
+
+/// True if an expr reads a target name (self-referential assign like `x = x | {..}`).
+/// Lambda bodies are skipped: their references are deferred, not read at assign time.
+struct SelfRefFinder<'a> {
+    targets: &'a [&'a str],
+    found: bool,
+}
+
+impl MutSelfWalker for SelfRefFinder<'_> {
+    fn walk_identifier(&mut self, identifier: &ast::Identifier) {
+        if let Some(first) = identifier.names.first()
+            && self.targets.contains(&first.node.as_str())
+        {
+            self.found = true;
+        }
+    }
+    fn walk_lambda_expr(&mut self, _lambda_expr: &ast::LambdaExpr) {}
+}
 
 /// Impl TypedResultWalker for Evaluator to visit AST nodes to evaluate the result.
 impl<'ctx> TypedResultWalker<'ctx> for Evaluator<'ctx> {
@@ -109,17 +127,38 @@ impl<'ctx> TypedResultWalker<'ctx> for Evaluator<'ctx> {
         if let Some(ty) = &assign_stmt.ty {
             value = type_pack_and_check(self, &value, vec![&ty.node.to_string()], false);
         }
+        let self_ref = {
+            let targets: Vec<&str> = assign_stmt
+                .targets
+                .iter()
+                .map(|t| t.node.name.node.as_str())
+                .collect();
+            let mut finder = SelfRefFinder {
+                targets: &targets,
+                found: false,
+            };
+            finder.walk_expr(&assign_stmt.value.node);
+            finder.found
+        };
         if assign_stmt.targets.len() == 1 {
             // Store the single target
             let name = &assign_stmt.targets[0];
             // Deep copy the value to ensure assign-by-value semantics.
             // This mirrors the behavior of multi-target assignment below.
             let value = self.value_deep_copy(&value);
+            *self.lazy_reassign.borrow_mut() = self_ref;
+            defer! {
+                *self.lazy_reassign.borrow_mut() = false;
+            }
             self.walk_target_with_value(&name.node, value.clone())?;
         } else {
             // Store multiple targets
             for name in &assign_stmt.targets {
                 let value = self.value_deep_copy(&value);
+                *self.lazy_reassign.borrow_mut() = self_ref;
+                defer! {
+                    *self.lazy_reassign.borrow_mut() = false;
+                }
                 self.walk_target_with_value(&name.node, value.clone())?;
             }
         }
@@ -154,7 +193,13 @@ impl<'ctx> TypedResultWalker<'ctx> for Evaluator<'ctx> {
             }
         };
         // Store the target value
-        self.walk_target_with_value(&aug_assign_stmt.target.node, value.clone())?;
+        {
+            *self.lazy_reassign.borrow_mut() = true;
+            defer! {
+                *self.lazy_reassign.borrow_mut() = false;
+            }
+            self.walk_target_with_value(&aug_assign_stmt.target.node, value.clone())?;
+        }
         self.pop_target_var();
         Ok(value)
     }

--- a/crates/evaluator/src/schema.rs
+++ b/crates/evaluator/src/schema.rs
@@ -127,6 +127,7 @@ impl SchemaEvalContext {
                     levels: other.levels.clone(),
                     cal_times: other.cal_times.clone(),
                     setters: other.setters.clone(),
+                    resolved: other.resolved.clone(),
                 })))
             }
         }

--- a/tests/grammar/assign/reassign_lazy_read/main.k
+++ b/tests/grammar/assign/reassign_lazy_read/main.k
@@ -1,0 +1,4 @@
+_v = "base"
+r1 = _v
+_v = "override"
+r2 = _v

--- a/tests/grammar/assign/reassign_lazy_read/stdout.golden
+++ b/tests/grammar/assign/reassign_lazy_read/stdout.golden
@@ -1,0 +1,2 @@
+r1: override
+r2: override

--- a/tests/grammar/multi_file_compilation/simple/simple_5/main.k
+++ b/tests/grammar/multi_file_compilation/simple/simple_5/main.k
@@ -1,0 +1,2 @@
+_replicas = 1
+deployment = {name = "web", replicas = _replicas}

--- a/tests/grammar/multi_file_compilation/simple/simple_5/pkg.k
+++ b/tests/grammar/multi_file_compilation/simple/simple_5/pkg.k
@@ -1,0 +1,1 @@
+_replicas = 3

--- a/tests/grammar/multi_file_compilation/simple/simple_5/settings.yaml
+++ b/tests/grammar/multi_file_compilation/simple/simple_5/settings.yaml
@@ -1,0 +1,1 @@
+kcl_options: pkg.k

--- a/tests/grammar/multi_file_compilation/simple/simple_5/stdout.golden
+++ b/tests/grammar/multi_file_compilation/simple/simple_5/stdout.golden
@@ -1,0 +1,3 @@
+deployment:
+  name: web
+  replicas: 3

--- a/tests/grammar/multi_file_compilation/simple/simple_6/main.k
+++ b/tests/grammar/multi_file_compilation/simple/simple_6/main.k
@@ -1,0 +1,2 @@
+_config = {replicas = 1, name = "app"}
+config = _config

--- a/tests/grammar/multi_file_compilation/simple/simple_6/pkg.k
+++ b/tests/grammar/multi_file_compilation/simple/simple_6/pkg.k
@@ -1,0 +1,1 @@
+_config = _config | {replicas = 3}

--- a/tests/grammar/multi_file_compilation/simple/simple_6/settings.yaml
+++ b/tests/grammar/multi_file_compilation/simple/simple_6/settings.yaml
@@ -1,0 +1,1 @@
+kcl_options: pkg.k

--- a/tests/grammar/multi_file_compilation/simple/simple_6/stdout.golden
+++ b/tests/grammar/multi_file_compilation/simple/simple_6/stdout.golden
@@ -1,0 +1,3 @@
+config:
+  replicas: 3
+  name: app


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?

- [x] N

#### 2. What is the scope of this PR

Lazy-scope cache updates on reassignment in the evaluator (`update_lazy_scope_cache` in `crates/evaluator/src/lazy.rs`).

#### 3. Provide a description of the PR

- [x] Bug fix

KCL globals are order independent: a read resolves to the variable's final value regardless of where the read appears. Since the cache force-update added in #2075 and #2077, `update_lazy_scope_cache` writes the cache on every reassignment, so a read taken before a later reassignment returns the stale earlier value:

```kcl
_v = "base"
r1 = _v        # r1 was "base", should be "override"
_v = "override"
```

The same force-update also lets a lower-precedence setter overwrite a value a read already resolved from a higher-precedence one, for example a base definition walked after a conditional override in a later file of the same package, which shows up as a dropped override or an `Undefined` attribute.

The fix keeps the force-update for the cases it was added for, augmented assignments (`|=`, `+=`) and self-referential reassignments (`x = x | {...}`), and skips it for plain reassignment. It also refuses to overwrite a value already resolved from a later setter unless the write is the last setter.

#### 4. Are there any breaking changes?

- [x] N

#### 5. Are there test cases for these changes?

- [x] Unit Test

A single-file order-independence test (`tests/grammar/assign/reassign_lazy_read`) and two multi-file fixtures (`tests/grammar/multi_file_compilation/simple/simple_5` and `simple_6`): a value derived in a base file from a variable a later file overrides, and a config union-merged across files. Each fails on the current evaluator and passes with this change. The full grammar suite is otherwise unchanged.
