### PR TITLE
Add is_IPv6 to net and validations to datetime

### DIFF
--- a/crates/api/src/service/service_impl.rs
+++ b/crates/api/src/service/service_impl.rs
@@ -221,9 +221,9 @@ impl KclServiceImpl {
     /// assert_eq!(result.type_errors.len(), 0);
     /// assert_eq!(result.symbols.len(), 12);
     /// assert_eq!(result.scopes.len(), 3);
-    /// assert_eq!(result.node_symbol_map.len(), 193);
-    /// assert_eq!(result.symbol_node_map.len(), 193);
-    /// assert_eq!(result.fully_qualified_name_map.len(), 204);
+    /// assert_eq!(result.node_symbol_map.len(), 196);
+    /// assert_eq!(result.symbol_node_map.len(), 196);
+    /// assert_eq!(result.fully_qualified_name_map.len(), 207);
     /// assert_eq!(result.pkg_scope_map.len(), 3);
     /// ```
     #[inline]

--- a/crates/loader/src/snapshots/kcl_loader__tests__builtin_call_0.snap
+++ b/crates/loader/src/snapshots/kcl_loader__tests__builtin_call_0.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/loader/src/tests.rs
-assertion_line: 37
 expression: "format! (\"{:#?}\", p.symbols.values())"
 ---
 [
@@ -89,27 +88,6 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
             },
         ),
         attrs: [
-            SymbolRef {
-                id: Index {
-                    index: 151,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 152,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 153,
-                    generation: 0,
-                },
-                kind: Function,
-            },
             SymbolRef {
                 id: Index {
                     index: 154,
@@ -295,6 +273,27 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
             SymbolRef {
                 id: Index {
                     index: 180,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 181,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 182,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 183,
                     generation: 0,
                 },
                 kind: Function,

--- a/crates/loader/src/snapshots/kcl_loader__tests__builtin_call_1.snap
+++ b/crates/loader/src/snapshots/kcl_loader__tests__builtin_call_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/loader/src/tests.rs
-assertion_line: 38
 expression: "format! (\"{:#?}\", p.symbols.values())"
 ---
 [
@@ -248,27 +247,6 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
         attrs: [
             SymbolRef {
                 id: Index {
-                    index: 151,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 152,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 153,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
                     index: 154,
                     generation: 0,
                 },
@@ -452,6 +430,27 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
             SymbolRef {
                 id: Index {
                     index: 180,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 181,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 182,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 183,
                     generation: 0,
                 },
                 kind: Function,
@@ -497,27 +496,6 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
         attrs: [
             SymbolRef {
                 id: Index {
-                    index: 151,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 152,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 153,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
                     index: 154,
                     generation: 0,
                 },
@@ -701,6 +679,27 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
             SymbolRef {
                 id: Index {
                     index: 180,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 181,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 182,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 183,
                     generation: 0,
                 },
                 kind: Function,
@@ -746,27 +745,6 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
         attrs: [
             SymbolRef {
                 id: Index {
-                    index: 151,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 152,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 153,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
                     index: 154,
                     generation: 0,
                 },
@@ -950,6 +928,27 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
             SymbolRef {
                 id: Index {
                     index: 180,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 181,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 182,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 183,
                     generation: 0,
                 },
                 kind: Function,

--- a/crates/loader/src/snapshots/kcl_loader__tests__builtin_call_2.snap
+++ b/crates/loader/src/snapshots/kcl_loader__tests__builtin_call_2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/loader/src/tests.rs
-assertion_line: 39
 expression: "format! (\"{:#?}\", p.symbols.values())"
 ---
 [
@@ -580,27 +579,6 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
         attrs: [
             SymbolRef {
                 id: Index {
-                    index: 151,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 152,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 153,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
                     index: 154,
                     generation: 0,
                 },
@@ -784,6 +762,27 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
             SymbolRef {
                 id: Index {
                     index: 180,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 181,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 182,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 183,
                     generation: 0,
                 },
                 kind: Function,
@@ -829,27 +828,6 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
         attrs: [
             SymbolRef {
                 id: Index {
-                    index: 151,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 152,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 153,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
                     index: 154,
                     generation: 0,
                 },
@@ -1033,6 +1011,27 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
             SymbolRef {
                 id: Index {
                     index: 180,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 181,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 182,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 183,
                     generation: 0,
                 },
                 kind: Function,
@@ -1078,27 +1077,6 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
         attrs: [
             SymbolRef {
                 id: Index {
-                    index: 151,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 152,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
-                    index: 153,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
                     index: 154,
                     generation: 0,
                 },
@@ -1282,6 +1260,27 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
             SymbolRef {
                 id: Index {
                     index: 180,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 181,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 182,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 183,
                     generation: 0,
                 },
                 kind: Function,

--- a/crates/loader/src/snapshots/kcl_loader__tests__import_stmt_0.snap
+++ b/crates/loader/src/snapshots/kcl_loader__tests__import_stmt_0.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/loader/src/tests.rs
-assertion_line: 29
 expression: "format! (\"{:#?}\", p.symbols.values())"
 ---
 [
@@ -46,13 +45,6 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
             },
         ),
         attrs: [
-            SymbolRef {
-                id: Index {
-                    index: 53,
-                    generation: 0,
-                },
-                kind: Function,
-            },
             SymbolRef {
                 id: Index {
                     index: 54,
@@ -154,6 +146,13 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
             SymbolRef {
                 id: Index {
                     index: 68,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 69,
                     generation: 0,
                 },
                 kind: Function,
@@ -249,13 +248,6 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
         attrs: [
             SymbolRef {
                 id: Index {
-                    index: 53,
-                    generation: 0,
-                },
-                kind: Function,
-            },
-            SymbolRef {
-                id: Index {
                     index: 54,
                     generation: 0,
                 },
@@ -355,6 +347,13 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
             SymbolRef {
                 id: Index {
                     index: 68,
+                    generation: 0,
+                },
+                kind: Function,
+            },
+            SymbolRef {
+                id: Index {
+                    index: 69,
                     generation: 0,
                 },
                 kind: Function,
@@ -460,7 +459,7 @@ expression: "format! (\"{:#?}\", p.symbols.values())"
         def: Some(
             SymbolRef {
                 id: Index {
-                    index: 63,
+                    index: 64,
                     generation: 0,
                 },
                 kind: Function,

--- a/crates/runtime/src/addr.rs
+++ b/crates/runtime/src/addr.rs
@@ -102,6 +102,8 @@ pub fn kcl_get_fn_ptr_by_name(name: &str) -> u64 {
         "kcl_crypto_sha512" => crate::kcl_crypto_sha512 as *const () as u64,
         "kcl_crypto_uuid" => crate::kcl_crypto_uuid as *const () as u64,
         "kcl_datetime_date" => crate::kcl_datetime_date as *const () as u64,
+        "kcl_datetime_is_iso8601" => crate::kcl_datetime_is_iso8601 as *const () as u64,
+        "kcl_datetime_is_rfc3339" => crate::kcl_datetime_is_rfc3339 as *const () as u64,
         "kcl_datetime_now" => crate::kcl_datetime_now as *const () as u64,
         "kcl_datetime_ticks" => crate::kcl_datetime_ticks as *const () as u64,
         "kcl_datetime_today" => crate::kcl_datetime_today as *const () as u64,
@@ -200,6 +202,7 @@ pub fn kcl_get_fn_ptr_by_name(name: &str) -> u64 {
         "kcl_net_is_IP" => crate::kcl_net_is_IP as *const () as u64,
         "kcl_net_is_IP_in_CIDR" => crate::kcl_net_is_IP_in_CIDR as *const () as u64,
         "kcl_net_is_IPv4" => crate::kcl_net_is_IPv4 as *const () as u64,
+        "kcl_net_is_IPv6" => crate::kcl_net_is_IPv6 as *const () as u64,
         "kcl_net_is_global_unicast_IP" => crate::kcl_net_is_global_unicast_IP as *const () as u64,
         "kcl_net_is_interface_local_multicast_IP" => {
             crate::kcl_net_is_interface_local_multicast_IP as *const () as u64

--- a/crates/runtime/src/datetime/mod.rs
+++ b/crates/runtime/src/datetime/mod.rs
@@ -112,3 +112,50 @@ fn validate_date(date: &str, format: &str) -> bool {
         .or_else(|_| NaiveTime::parse_from_str(date, format).map(|_| true))
         .is_ok()
 }
+
+/// Validates whether the provided string is a valid RFC 3339 date-time.
+/// `is_rfc3339(str) -> bool`
+/// # Safety
+/// The caller must ensure that `ctx`, `args`, and `kwargs` are valid pointers
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn kcl_datetime_is_rfc3339(
+    ctx: *mut kcl_context_t,
+    args: *const kcl_value_ref_t,
+    kwargs: *const kcl_value_ref_t,
+) -> *const kcl_value_ref_t {
+    let ctx = unsafe { mut_ptr_as_ref(ctx) };
+    let args = unsafe { ptr_as_ref(args) };
+    let kwargs = unsafe { ptr_as_ref(kwargs) };
+    if let Some(date) = get_call_arg_str(args, kwargs, 0, Some("date")) {
+        let is_valid = chrono::DateTime::parse_from_rfc3339(&date).is_ok();
+        return ValueRef::bool(is_valid).into_raw(ctx);
+    }
+    panic!("is_rfc3339() missing 1 required positional argument: 'date'");
+}
+
+/// Validates whether the provided string is a valid ISO 8601 duration or date-time.
+/// `is_iso8601(str) -> bool`
+/// # Safety
+/// The caller must ensure that `ctx`, `args`, and `kwargs` are valid pointers
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn kcl_datetime_is_iso8601(
+    ctx: *mut kcl_context_t,
+    args: *const kcl_value_ref_t,
+    kwargs: *const kcl_value_ref_t,
+) -> *const kcl_value_ref_t {
+    let ctx = unsafe { mut_ptr_as_ref(ctx) };
+    let args = unsafe { ptr_as_ref(args) };
+    let kwargs = unsafe { ptr_as_ref(kwargs) };
+    if let Some(date) = get_call_arg_str(args, kwargs, 0, Some("date")) {
+        // Check if it is a valid RFC 3339 (which is an ISO 8601 profile)
+        if chrono::DateTime::parse_from_rfc3339(&date).is_ok() {
+            return ValueRef::bool(true).into_raw(ctx);
+        }
+        // Fallback: Check if it is an ISO 8601 Duration
+        // A standard regex for ISO 8601 durations (e.g., P3Y6M4DT12H30M5.5S)
+        let re = fancy_regex::Regex::new(r"^P(?!$)(?:\d+(?:\.\d+)?Y)?(?:\d+(?:\.\d+)?M)?(?:\d+(?:\.\d+)?W)?(?:\d+(?:\.\d+)?D)?(?:T(?=\d)(?:\d+(?:\.\d+)?H)?(?:\d+(?:\.\d+)?M)?(?:\d+(?:\.\d+)?S)?)?$").unwrap();
+        let is_valid = re.is_match(&date).unwrap_or(false);
+        return ValueRef::bool(is_valid).into_raw(ctx);
+    }
+    panic!("is_iso8601() missing 1 required positional argument: 'date'");
+}

--- a/crates/runtime/src/kcl.h
+++ b/crates/runtime/src/kcl.h
@@ -255,6 +255,10 @@ kcl_value_ref_t* kcl_crypto_uuid(kcl_context_t* ctx, kcl_value_ref_t* _args, kcl
 
 kcl_value_ref_t* kcl_datetime_date(kcl_context_t* ctx, kcl_value_ref_t* _args, kcl_value_ref_t* _kwargs);
 
+kcl_value_ref_t* kcl_datetime_is_iso8601(kcl_context_t* ctx, kcl_value_ref_t* args, kcl_value_ref_t* kwargs);
+
+kcl_value_ref_t* kcl_datetime_is_rfc3339(kcl_context_t* ctx, kcl_value_ref_t* args, kcl_value_ref_t* kwargs);
+
 kcl_value_ref_t* kcl_datetime_now(kcl_context_t* ctx, kcl_value_ref_t* args, kcl_value_ref_t* kwargs);
 
 kcl_value_ref_t* kcl_datetime_ticks(kcl_context_t* ctx, kcl_value_ref_t* _args, kcl_value_ref_t* _kwargs);
@@ -440,6 +444,8 @@ kcl_value_ref_t* kcl_net_is_IP(kcl_context_t* ctx, kcl_value_ref_t* args, kcl_va
 kcl_value_ref_t* kcl_net_is_IP_in_CIDR(kcl_context_t* ctx, kcl_value_ref_t* args, kcl_value_ref_t* kwargs);
 
 kcl_value_ref_t* kcl_net_is_IPv4(kcl_context_t* ctx, kcl_value_ref_t* args, kcl_value_ref_t* kwargs);
+
+kcl_value_ref_t* kcl_net_is_IPv6(kcl_context_t* ctx, kcl_value_ref_t* args, kcl_value_ref_t* kwargs);
 
 kcl_value_ref_t* kcl_net_is_global_unicast_IP(kcl_context_t* ctx, kcl_value_ref_t* args, kcl_value_ref_t* kwargs);
 

--- a/crates/runtime/src/net/mod.rs
+++ b/crates/runtime/src/net/mod.rs
@@ -320,6 +320,33 @@ pub unsafe extern "C-unwind" fn kcl_net_is_IPv4(
     panic!("is_IPv4() missing 1 required positional argument: 'ip'");
 }
 
+// is_IPv6(ip: str) -> bool
+
+/// # Safety
+/// This function involves raw pointer manipulation and should be used with caution.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn kcl_net_is_IPv6(
+    ctx: *mut kcl_context_t,
+    args: *const kcl_value_ref_t,
+    kwargs: *const kcl_value_ref_t,
+) -> *const kcl_value_ref_t {
+    let args = unsafe { ptr_as_ref(args) };
+    let kwargs = unsafe { ptr_as_ref(kwargs) };
+
+    if let Some(ip) = get_call_arg_str(args, kwargs, 0, Some("ip")) {
+        if let Ok(_addr) = Ipv6Addr::from_str(ip.as_ref()) {
+            return unsafe { kcl_value_True(ctx) };
+        }
+        if let Ok(_addr) = Ipv4Addr::from_str(ip.as_ref()) {
+            return unsafe { kcl_value_False(ctx) };
+        }
+
+        return unsafe { kcl_value_False(ctx) };
+    }
+
+    panic!("is_IPv6() missing 1 required positional argument: 'ip'");
+}
+
 // is_IP(ip: str) -> bool
 
 /// # Safety

--- a/crates/sema/src/builtin/system_module.rs
+++ b/crates/sema/src/builtin/system_module.rs
@@ -352,6 +352,22 @@ register_net_member! {
         false,
         None,
     )
+    is_IPv6 => Type::function(
+        None,
+        Type::bool_ref(),
+        &[
+            Parameter {
+                name: "ip".to_string(),
+                ty: Type::str_ref(),
+                has_default: false,
+                default_value: None,
+                range: dummy_range(),
+            },
+        ],
+        r#"Whether ip is a IPv6 one."#,
+        false,
+        None,
+    )
     is_IP => Type::function(
         None,
         Type::bool_ref(),
@@ -946,6 +962,38 @@ register_datetime_member! {
             },
         ],
         r#"Validate whether the provided date string matches the specified format."#,
+        false,
+        None,
+    )
+    is_rfc3339 => Type::function(
+        None,
+        Type::bool_ref(),
+        &[
+            Parameter {
+                name: "date".to_string(),
+                ty: Type::str_ref(),
+                has_default: false,
+                default_value: None,
+                range: dummy_range(),
+            },
+        ],
+        r#"Validate whether the provided date string is a valid RFC 3339 date-time."#,
+        false,
+        None,
+    )
+    is_iso8601 => Type::function(
+        None,
+        Type::bool_ref(),
+        &[
+            Parameter {
+                name: "date".to_string(),
+                ty: Type::str_ref(),
+                has_default: false,
+                default_value: None,
+                range: dummy_range(),
+            },
+        ],
+        r#"Validate whether the provided date string is a valid ISO 8601 duration or date-time."#,
         false,
         None,
     )

--- a/tests/runtime/datetime/test_datetime.py
+++ b/tests/runtime/datetime/test_datetime.py
@@ -1,6 +1,12 @@
 # Copyright The KCL Authors. All rights reserved.
 
+import sys
+import os
 import unittest
+
+# Add the parent directory to the path to import kcl_runtime
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(parent_dir)
 
 import kcl_runtime as kcl_runtime
 
@@ -9,15 +15,33 @@ import kcl_runtime as kcl_runtime
 _Dylib = kcl_runtime.KclRuntimeDylib()
 
 
-class kclx_Crypto:
+class kclx_Datetime:
     def __init__(self, dylib_=None):
         self.dylib = dylib_ if dylib_ else _Dylib
 
+    def is_rfc3339(self, date: str) -> bool:
+        return self.dylib.Invoke("datetime.is_rfc3339", date)
+
+    def is_iso8601(self, date: str) -> bool:
+        return self.dylib.Invoke("datetime.is_iso8601", date)
+
+
+kclxdatetime = kclx_Datetime(_Dylib)
+
 
 class BaseTest(unittest.TestCase):
-    def test_foo(self):
-        self.assertTrue(True)
+    def test_is_rfc3339(self):
+        self.assertTrue(kclxdatetime.is_rfc3339("2024-03-20T15:30:00Z"))
+        self.assertTrue(kclxdatetime.is_rfc3339("2024-03-20T15:30:00+08:00"))
+        self.assertFalse(kclxdatetime.is_rfc3339("2024-03-20"))
+
+    def test_is_iso8601(self):
+        self.assertTrue(kclxdatetime.is_iso8601("2024-03-20T15:30:00Z"))
+        self.assertTrue(kclxdatetime.is_iso8601("P3Y6M4DT12H30M5S"))
+        self.assertTrue(kclxdatetime.is_iso8601("P1Y"))
+        self.assertFalse(kclxdatetime.is_iso8601("invalid"))
 
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/runtime/net/test_net.py
+++ b/tests/runtime/net/test_net.py
@@ -17,6 +17,9 @@ class kclx_Net:
     def __init__(self, dylib_=None):
         self.dylib = dylib_ if dylib_ else _Dylib
 
+    def is_IPv6(self, value: str) -> bool:
+        return self.dylib.Invoke(f"net.is_IPv6", value)
+
     def is_global_unicast_IP(self, value: str) -> bool:
         return self.dylib.Invoke(f"net.is_global_unicast_IP", value)
 
@@ -43,6 +46,12 @@ kclxnet = kclx_Net(_Dylib)
 
 
 class BaseTest(unittest.TestCase):
+    def test_is_IPv6(self):
+        self.assertTrue(kclxnet.is_IPv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334"))
+        self.assertTrue(kclxnet.is_IPv6("::1"))
+        self.assertFalse(kclxnet.is_IPv6("192.168.1.1"))
+        self.assertFalse(kclxnet.is_IPv6("invalid_ip"))
+
     def test_is_interface_local_multicast_IP(self):
         self.assertFalse(kclxnet.is_interface_local_multicast_IP("224.0.0.0"))
         self.assertTrue(kclxnet.is_interface_local_multicast_IP("ff11::1"))


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y
fix #1888

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->
`crates/runtime/src/net/mod.rs`
`crates/runtime/src/datetime/mod.rs`
`crates/sema/src/builtin/system_module.rs`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->
Adds `is_IPv6` validation to the `net` system package. Adds `is_rfc3339` and `is_iso8601` validations to the `datetime` package using `chrono` and `fancy_regex`. This provides better native support for validating JSON schema formats in KCL.
#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
Added unit tests in `tests/runtime/net/test_net.py` and `tests/runtime/datetime/test_datetime.py` to verify the new C-ABI functionality.
