### PR TITLE
fix(sema): prevent swallowed errors for unresolved schema expressions…

### DIFF
--- a/crates/sema/src/resolver/test_data/valid_mixin_host_attr.k
+++ b/crates/sema/src/resolver/test_data/valid_mixin_host_attr.k
@@ -1,0 +1,9 @@
+# Valid: mixin accesses attributes from the host schema at runtime.
+# This must NOT produce a type error.
+mixin FullnameMixin:
+    fullName = "{} {}".format(firstName, lastName)
+
+schema Person:
+    mixin [FullnameMixin]
+    firstName: str
+    lastName: str

--- a/crates/sema/src/resolver/test_fail_data/invalid_mixin_1.k
+++ b/crates/sema/src/resolver/test_fail_data/invalid_mixin_1.k
@@ -1,0 +1,12 @@
+mixin BrokenMixin:
+    something: str = "abc"
+    broken_1 = UndefinedSchema {}
+    broken_2 = UndefinedSchema("foobar")
+    broken_3 = UndefinedSchema
+
+schema Foo:
+    mixin [
+        BrokenMixin
+    ]
+
+foo = Foo {}

--- a/crates/sema/src/resolver/tests.rs
+++ b/crates/sema/src/resolver/tests.rs
@@ -167,6 +167,7 @@ fn test_resolve_program_fail() {
         "comp_clause_error_4.k",
         "config_expr.k",
         "invalid_mixin_0.k",
+        "invalid_mixin_1.k",
         "lambda_schema_ty_0.k",
         "lambda_schema_ty_1.k",
         "lambda_schema_ty_2.k",
@@ -1172,5 +1173,41 @@ fn clear_cache_test() {
     assert_eq!(
         first_scope.schema_mapping.len(),
         second_scope.schema_mapping.len()
+    );
+}
+
+#[test]
+fn test_resolve_program_valid_mixin_host_attr() {
+    let path = "./src/resolver/test_data/valid_mixin_host_attr.k";
+    let mut program = parse_program(path).unwrap();
+    let scope = resolve_program(&mut program);
+    assert!(
+        scope.handler.diagnostics.is_empty(),
+        "valid mixin host-attr access produced unexpected errors: {:?}",
+        scope.handler.diagnostics
+    );
+}
+
+#[test]
+fn test_resolve_program_invalid_mixin_error_count() {
+    let path = "./src/resolver/test_fail_data/invalid_mixin_1.k";
+    let mut program = parse_program(path).unwrap();
+    let scope = resolve_program(&mut program);
+    let msgs: Vec<&str> = scope
+        .handler
+        .diagnostics
+        .iter()
+        .flat_map(|d| d.messages.iter().map(|m| m.message.as_str()))
+        .collect();
+    assert_eq!(
+        msgs.len(),
+        3,
+        "Expected exactly 3 'UndefinedSchema is not defined' errors (one per broken_1/2/3), got: {:?}",
+        msgs
+    );
+    assert!(
+        msgs.iter().all(|m| m.contains("UndefinedSchema")),
+        "All errors should reference 'UndefinedSchema', got: {:?}",
+        msgs
     );
 }

--- a/crates/sema/src/resolver/var.rs
+++ b/crates/sema/src/resolver/var.rs
@@ -54,9 +54,10 @@ impl<'ctx> Resolver<'_> {
                     // raise an error and return an any type.
                     // At present, retaining certain dynamic characteristics for mixins and rules
                     // requires further consideration of their semantics.
+                    let is_type_ref = name.starts_with(|c: char| c.is_uppercase());
                     if ty.is_none()
                         && scope_ty.is_none()
-                        && !schema_ty.is_mixin
+                        && (!schema_ty.is_mixin || is_type_ref)
                         && !schema_ty.is_rule
                     {
                         vec![self.lookup_type_from_scope(name, range)]


### PR DESCRIPTION
### fix(sema): prevent swallowed errors for unresolved schema expressions in mixins (#1914)

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

fix #1914

#### 2. What is the scope of this PR (e.g. component or file name):

- `crates/sema/src/resolver/var.rs`
- `crates/sema/src/resolver/tests.rs`
- `crates/sema/src/resolver/test_fail_data/invalid_mixin_1.k`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [x] Affects user behaviors (Properly emits compile errors instead of silently generating empty dicts)
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

**Motivation & Details:**
Previously, if a mixin contained an unresolved schema reference (e.g., `UndefinedSchema {}`), the semantic analyzer (`var.rs`) would swallow the `is not defined` error. This happened because KCL intentionally suppresses undefined variable errors inside mixins to allow dynamic access to host schema attributes. 

This PR fixes the issue by differentiating between **attributes** (snake_case/camelCase) and **schema/type references** (PascalCase). The `is_mixin` error suppression is now bypassed if the undefined name starts with an uppercase letter, enforcing strict type resolution for explicit schemas while preserving KCL's dynamic attribute semantics for mixins.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

**Test Details:**
Added two new unit tests in `crates/sema/src/resolver/tests.rs`:
1. `test_resolve_program_invalid_mixin_error_count`: Parses `invalid_mixin_1.k` (the repro from #1914) to verify that exactly 3 `UndefinedSchema is not defined` diagnostics are emitted.
2. `test_resolve_program_valid_mixin_host_attr`: Parses `valid_mixin_host_attr.k` to prevent regressions, ensuring lowercase host attributes accessed dynamically inside mixins do not throw false-positive errors.