### PR TITLE
fix(evaluator): avoid recursive global aliases in evaluation

### DIFF
--- a/crates/evaluator/src/lib.rs
+++ b/crates/evaluator/src/lib.rs
@@ -208,7 +208,8 @@ impl<'ctx> Evaluator<'ctx> {
         }
         // Deal scalars
         for scalar in scalars.iter() {
-            self.dict_insert_merge_value(&mut global_dict, SCALAR_KEY, scalar);
+            let scalar = scalar.deep_copy();
+            self.dict_insert_merge_value(&mut global_dict, SCALAR_KEY, &scalar);
         }
         // Deal global variables
         for (name, value) in globals.iter() {

--- a/crates/evaluator/src/snapshots/kcl_evaluator__tests__issue_2046_public_scalar_alias.snap
+++ b/crates/evaluator/src/snapshots/kcl_evaluator__tests__issue_2046_public_scalar_alias.snap
@@ -1,0 +1,8 @@
+---
+source: crates/evaluator/src/tests.rs
+assertion_line: 585
+expression: "format! (\"{}\", evaluator.run().unwrap().1)"
+---
+bean: test
+test:
+  bean: test

--- a/crates/evaluator/src/tests.rs
+++ b/crates/evaluator/src/tests.rs
@@ -464,7 +464,7 @@ test = TestSchema{custom_roles=[_test_role]}.get_roles()
 evaluator_snapshot! {lambda_9, r#"
 foo = lambda values: [int] -> [int] {
     [v for v in values]
-}    
+}
 
 schema Bar:
     values = [123]
@@ -580,6 +580,13 @@ version = "v0.1.0"
 
 evaluator_snapshot! {list_comp1, r#"
 a = [ x for x in "你好"]
+"#}
+
+evaluator_snapshot! {issue_2046_public_scalar_alias, r#"
+test = {
+    bean: "test"
+}
+test
 "#}
 
 #[test]


### PR DESCRIPTION


#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y Fixes #2046

#### 2. What is the scope of this PR (e.g. component or file name):

The KCL evaluator.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

As described in the commit body:

The problem stated in #2046 is that dusing the globals planning in the evaluator, an alias to `test` is placed in the global dict under `"test"`. However, this `test` is already a reference to the global object, creating a recursive object. When this is evaluated in ValueRef::plan, we run into an infinite recursion (as it preforms an object traversal) which leads to a stack overflow. By copying the scalar during the dictionary merge we do not input an alias to the global dict but rather a scalar copy, avoiding this self-reference in the object and thus avoiding the infinite recursion.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y

**NOTE**: however I am not sure the output is according to the full language spec. The current output for the test case:

```kcl
test = {
  bean: "test"
}
test
```

Is

```yaml
bean: test
test:
  bean: test
```

IMO this makes sense, as it prints the `test` object as defined (standard behaviour if we were to omit the `test` reference at the end of the KCL file which created the issue so far), and then prints the contents of `test` (`bean: test`) due to its reference at the end. This is inline with the behaviour of a program such as:

```kcl
test = {
  bean: "test"
}

other = {
   value = test
}
```

Where `value` gets the value of `test` assigned. However, I am not the language designer, so maybe there are other opinions on this?

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

Yes, I added a regression test to validate such aliasing based on the test case provided by the issue.


> **AI NOTE**: I used AI in combination to a debugger to analyse this issue and pinpoint the offending code. However, no code that is part of this PR was generated by AI.
