### PR TITLE
fix(driver): guard current_dir() panic on wasm32 (#2104)

### DIFF
--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -325,7 +325,15 @@ pub fn lookup_workspace(path: &str) -> io::Result<WorkSpaceKind> {
 pub fn get_pkg_list(pkgpath: &str) -> Result<Vec<String>> {
     let mut dir_list: Vec<String> = Vec::new();
     let mut dir_map: HashSet<String> = HashSet::new();
+    // `std::env::current_dir()` is an unconditional panic on `wasm32-wasip1`
+    // (Rust std has no cwd concept on wasip1). The only consumer of `cwd` in
+    // this function is the `pkgpath.is_empty()` branch below, where "." is a
+    // correct walk-root substitute: WASI hosts already map "." via preopens.
+    // Native callers keep the prior behaviour.
+    #[cfg(not(target_arch = "wasm32"))]
     let cwd = std::env::current_dir()?;
+    #[cfg(target_arch = "wasm32")]
+    let cwd = std::path::PathBuf::from(".");
 
     let pkgpath = if pkgpath.is_empty() {
         cwd.to_string_lossy().to_string()


### PR DESCRIPTION
## Problem

`std::env::current_dir()` panics on `wasm32-wasip1` (`no filesystem on wasm` —wasip1 has no cwd). It's hit at runtime in `driver::get_pkg_list`, blockingembedding kcl-lang in a WASI sandbox.

## Fix

cfg-guard the call. `cwd` is only used as the walk-root for the`pkgpath.is_empty()` branch, so `"."` (which WASI hosts map via preopens) is acorrect substitute. Native builds are unchanged.

```rust
#[cfg(not(target_arch = "wasm32"))]
let cwd = std::env::current_dir()?;
#[cfg(target_arch = "wasm32")]
let cwd = std::path::PathBuf::from(".");

Tests

- cargo test -p kcl-driver — 6/6 pass
- cargo build -p kcl-driver --target wasm32-wasip1 — comp
- cargo fmt --check — clean
```
  
Part of #2104.