### PR TITLE
fix(runtime): release plugin dispatch lock before invoking handler to…

### DIFF
--- a/crates/runtime/src/stdlib/plugin.rs
+++ b/crates/runtime/src/stdlib/plugin.rs
@@ -91,8 +91,13 @@ pub unsafe extern "C-unwind" fn kcl_plugin_invoke_json(
     args: *const c_char,
     kwargs: *const c_char,
 ) -> *const c_char {
-    let fn_ptr_guard = PLUGIN_HANDLER_FN_PTR.lock().unwrap();
-    if let Some(fn_ptr) = *fn_ptr_guard {
+    // Release the dispatch lock before invoking the handler. The fn pointer is
+    // `Copy`, so copy it out and drop the guard first: holding the lock across
+    // the user callback deadlocks any nested KCL evaluation the handler triggers
+    // (e.g. a plugin that renders another Package), because `std::sync::Mutex`
+    // is not reentrant.
+    let fn_ptr = { *PLUGIN_HANDLER_FN_PTR.lock().unwrap() };
+    if let Some(fn_ptr) = fn_ptr {
         fn_ptr(method, args, kwargs)
     } else {
         panic!("plugin handler is nil, should call kcl_plugin_init at first");
@@ -118,4 +123,39 @@ unsafe extern "C-unwind" {
         args: *const c_char,
         kwargs: *const c_char,
     ) -> *const c_char;
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use std::ptr;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static LOCK_FREE_DURING_HANDLER: AtomicBool = AtomicBool::new(false);
+
+    /// Records whether the dispatch lock is available while the handler runs.
+    /// With the lock released before dispatch (the fix), `try_lock` succeeds;
+    /// if the lock were still held (the pre-fix bug) it would fail here — and a
+    /// genuinely reentrant handler would deadlock instead of returning.
+    extern "C-unwind" fn probe_handler(
+        _method: *const c_char,
+        _args: *const c_char,
+        _kwargs: *const c_char,
+    ) -> *const c_char {
+        LOCK_FREE_DURING_HANDLER.store(PLUGIN_HANDLER_FN_PTR.try_lock().is_ok(), Ordering::SeqCst);
+        ptr::null()
+    }
+
+    #[test]
+    fn dispatch_lock_released_before_handler() {
+        unsafe {
+            kcl_plugin_init(probe_handler);
+            kcl_plugin_invoke_json(ptr::null(), ptr::null(), ptr::null());
+        }
+        assert!(
+            LOCK_FREE_DURING_HANDLER.load(Ordering::SeqCst),
+            "dispatch lock must be released before invoking the plugin handler; \
+             holding it across the callback deadlocks reentrant/nested KCL evaluation"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

  `kcl_plugin_invoke_json` holds the `PLUGIN_HANDLER_FN_PTR` mutex across the user handler call. `std::sync::Mutex` isn't reentrant, so a handler  that triggers a nested KCL eval (invoking a plugin again) deadlocks on the second lock.

  ## Fix

  Copy the fn pointer out, drop the guard, then call the handler.

Before:
<img width="1610" height="765" alt="image" src="https://github.com/user-attachments/assets/ce415424-72d7-4413-8026-143b62c62f4e" />
After:
<img width="1280" height="286" alt="image" src="https://github.com/user-attachments/assets/f187a00d-ade4-4a40-a78b-22fbbeb00551" />


 Along with #2105 , this pr closes #2104 .
