### PR TITLE
chore: bump workspace version to 0.12.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ kcl-version = { path = "crates/version" }
 serde_yaml = { path = "3rdparty/serde_yaml" }
 
 [workspace.package]
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 rust-version = "1.83"
 exclude = [".github/"]


### PR DESCRIPTION
## Summary

- Bump `[workspace.package]` version from `0.12.3` to `0.12.4` in `Cargo.toml`
- All kcl-* sub-crates inherit the version through `version.workspace = true`, so no other Cargo.toml changes are needed

## Test plan

- [ ] `cargo build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)