### PR TITLE
fix(lsp): perform inherited attribute lookup on schema resolution

### DIFF
--- a/crates/sema/src/resolver/ty.rs
+++ b/crates/sema/src/resolver/ty.rs
@@ -416,7 +416,10 @@ impl<'ctx> Resolver<'_> {
             // empty dict {}
             TypeKind::Any => true,
             // single key: {key1: value1}
-            TypeKind::StrLit(s) => !schema_ty.attrs.is_empty() && schema_ty.attrs.contains_key(s),
+            TypeKind::StrLit(s) => {
+                let (attrs, has_index_signature) = Self::get_schema_attrs(schema_ty);
+                attrs.contains(s) || has_index_signature
+            }
             // multi key: {
             // key1: value1
             // key2: value2

--- a/crates/tools/src/LSP/src/completion.rs
+++ b/crates/tools/src/LSP/src/completion.rs
@@ -2135,6 +2135,14 @@ mod tests {
         Some('\n')
     );
 
+    completion_label_without_builtin_func_test_snapshot!(
+        schema_attr_newline_completion_2,
+        "src/test_data/completion_test/newline/schema/schema_2/schema_2.k",
+        13,
+        8,
+        Some('\n')
+    );
+
     completion_label_without_system_pkg_test_snapshot!(
         import_internal_pkg_test,
         "src/test_data/completion_test/import/internal/main.k",

--- a/crates/tools/src/LSP/src/snapshots/kcl_language_server__completion__tests__schema_attr_newline_completion_2.snap
+++ b/crates/tools/src/LSP/src/snapshots/kcl_language_server__completion__tests__schema_attr_newline_completion_2.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tools/src/LSP/src/completion.rs
+assertion_line: 2138
+expression: "format! (\"{:?}\", got_labels)"
+---
+["count"]

--- a/crates/tools/src/LSP/src/test_data/completion_test/newline/schema/schema_2/schema_2.k
+++ b/crates/tools/src/LSP/src/test_data/completion_test/newline/schema/schema_2/schema_2.k
@@ -1,0 +1,15 @@
+schema BaseConfig:
+    name: str
+
+schema Config(BaseConfig):
+    count: int
+
+schema Name:
+    config: Config
+
+n = Name{
+    config: {
+        name = ""
+        
+    }
+}


### PR DESCRIPTION
Relates-to: kcl-lang/kcl#1752

<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y, see #1752

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

The LSP semantic type resolver.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

The semantic type resolution to upsert a dict into a schema forgot to check inherited attributes from parent schemas when checking whether an attribute was part of a schema.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
