### PR TITLE
feat(fmt): honor .editorconfig for indentation (#1930)

### DIFF
--- a/crates/api/src/service/service_impl.rs
+++ b/crates/api/src/service/service_impl.rs
@@ -798,6 +798,7 @@ impl KclServiceImpl {
                 is_stdout: false,
                 omit_errors: true,
                 dry_run: args.dry_run,
+                ..Default::default()
             },
         )?;
         Ok(FormatPathResult { changed_paths })

--- a/crates/ast_pretty/src/lib.rs
+++ b/crates/ast_pretty/src/lib.rs
@@ -25,11 +25,18 @@ pub enum Indentation {
 }
 
 /// Printer config
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
+    /// Display width of a TAB character. Per the EditorConfig spec, this is a
+    /// *display* hint only — it does not change the bytes the printer emits
+    /// for a tab-indented line. In space-mode, `tab_len` is unused.
     pub tab_len: usize,
+    /// Width of a single indent level (in spaces when `use_spaces` is true).
     pub indent_len: usize,
+    /// `true` emits spaces (controlled by `indent_len`); `false` emits a
+    /// single TAB per indent level regardless of `indent_len`/`tab_len`.
     pub use_spaces: bool,
+    /// Whether to emit source comments in the printed output.
     pub write_comments: bool,
 }
 
@@ -346,9 +353,12 @@ impl<'p> Printer<'p> {
     }
 }
 
-/// Print AST to string. The default format is according to the KCL code style defined here: https://kcl-lang.io/docs/reference/lang/spec/codestyle
-pub fn print_ast_module(module: &Module) -> String {
-    let mut printer = Printer::default();
+/// Print AST to string with an explicit printer configuration. Use this when
+/// the caller needs to override defaults (e.g. to honor `.editorconfig`).
+/// The default format is according to the KCL code style defined here:
+/// https://kcl-lang.io/docs/reference/lang/spec/codestyle
+pub fn print_ast_module_with_config(module: &Module, cfg: Config) -> String {
+    let mut printer = Printer::new(cfg, &NoHook);
     printer.write_module(module);
     // Trim trailing newlines to ensure exactly one newline at EOF
     let trimmed = printer.out.trim_end_matches('\n');
@@ -357,6 +367,11 @@ pub fn print_ast_module(module: &Module) -> String {
     } else {
         format!("{}\n", trimmed)
     }
+}
+
+/// Print AST to string. The default format is according to the KCL code style defined here: https://kcl-lang.io/docs/reference/lang/spec/codestyle
+pub fn print_ast_module(module: &Module) -> String {
+    print_ast_module_with_config(module, Config::default())
 }
 
 /// Print AST to string

--- a/crates/ast_pretty/src/tests.rs
+++ b/crates/ast_pretty/src/tests.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use super::print_ast_module;
+use super::{Config, print_ast_module, print_ast_module_with_config};
 use kcl_parser::parse_file_force_errors;
 use pretty_assertions::assert_eq;
 
@@ -62,4 +62,73 @@ fn test_ast_printer() {
 
         assert_eq!(data_input, data_output, "Test failed on {}", case);
     }
+}
+
+/// Helper: a small fixture containing a nested schema that exercises indentation.
+const NESTED_SRC: &str = "x = {\n    a: {\n        b: 1\n    }\n}\n";
+
+#[test]
+fn test_print_ast_module_default_equivalent() {
+    // Calling print_ast_module must match calling print_ast_module_with_config
+    // with Config::default() byte-for-byte.
+    let module = parse_file_force_errors("nested.k", Some(NESTED_SRC.to_string())).unwrap();
+    let a = print_ast_module(&module);
+    let b = print_ast_module_with_config(&module, Config::default());
+    assert_eq!(a, b);
+}
+
+#[test]
+fn test_print_ast_module_two_space_indent() {
+    let module = parse_file_force_errors("nested.k", Some(NESTED_SRC.to_string())).unwrap();
+    let cfg = Config {
+        indent_len: 2,
+        ..Config::default()
+    };
+    let out = print_ast_module_with_config(&module, cfg);
+    // Every nested key gets exactly 2 spaces per level.
+    assert!(
+        out.contains("  a: {\n    b: 1\n  }\n}"),
+        "expected 2-space indent, got:\n{out}"
+    );
+}
+
+#[test]
+fn test_print_ast_module_tab_indent() {
+    let module = parse_file_force_errors("nested.k", Some(NESTED_SRC.to_string())).unwrap();
+    let cfg = Config {
+        use_spaces: false,
+        indent_len: 4,
+        tab_len: 4,
+        ..Config::default()
+    };
+    let out = print_ast_module_with_config(&module, cfg);
+    // In tab mode the printer emits a single TAB per indent level, regardless
+    // of `tab_len` or `indent_len`. The first nested level is one TAB and the
+    // deeper nested level is two TABs.
+    assert!(
+        out.contains("\n\ta: {\n\t\tb: 1\n\t}\n}\n"),
+        "expected one TAB per level, got:\n{out}"
+    );
+}
+
+#[test]
+fn test_print_ast_module_tab_len_does_not_affect_tab_mode_bytes() {
+    // `tab_len` is a display hint per the EditorConfig spec. Even setting it
+    // to 8 (the classic default) must not change the bytes emitted in tab mode.
+    let module = parse_file_force_errors("nested.k", Some(NESTED_SRC.to_string())).unwrap();
+    let cfg_small = Config {
+        use_spaces: false,
+        indent_len: 4,
+        tab_len: 2,
+        ..Config::default()
+    };
+    let cfg_large = Config {
+        use_spaces: false,
+        indent_len: 4,
+        tab_len: 8,
+        ..Config::default()
+    };
+    let small = print_ast_module_with_config(&module, cfg_small);
+    let large = print_ast_module_with_config(&module, cfg_large);
+    assert_eq!(small, large);
 }

--- a/crates/evaluator/src/node.rs
+++ b/crates/evaluator/src/node.rs
@@ -1590,8 +1590,12 @@ impl<'ctx> Evaluator<'ctx> {
                 };
                 if !skip_type_check {
                     if let Some(ty) = arg_type {
-                        arg_value =
-                            type_pack_and_check(self, &arg_value, vec![&ty.node.to_string()], false);
+                        arg_value = type_pack_and_check(
+                            self,
+                            &arg_value,
+                            vec![&ty.node.to_string()],
+                            false,
+                        );
                     }
                 }
                 // Mark positional argument as a local variable
@@ -1610,8 +1614,12 @@ impl<'ctx> Evaluator<'ctx> {
                 // Type check keyword arguments if type annotation is present
                 if !skip_type_check {
                     if let Some(ty) = arg_type {
-                        arg_value =
-                            type_pack_and_check(self, &arg_value, vec![&ty.node.to_string()], false);
+                        arg_value = type_pack_and_check(
+                            self,
+                            &arg_value,
+                            vec![&ty.node.to_string()],
+                            false,
+                        );
                     }
                 }
                 // Mark keyword argument as a local variable

--- a/crates/evaluator/src/tests.rs
+++ b/crates/evaluator/src/tests.rs
@@ -1218,7 +1218,8 @@ fn test_issue_1915_child_schema_arg_overrides_parent_type() {
     let p = load_packages(&LoadPackageOptions {
         paths: vec!["test.k".to_string()],
         load_opts: Some(LoadProgramOptions {
-            k_code_list: vec![r#"
+            k_code_list: vec![
+                r#"
 schema Parent[value: str]:
 schema Child[value: bool, extra: str](Parent):
     valueAttr: bool = value
@@ -1228,7 +1229,8 @@ positional = Child(True, "p")
 keyword = Child(value=False, extra="k")
 caller_keyword = Child(False, "c")
 "#
-            .to_string()],
+                .to_string(),
+            ],
             ..Default::default()
         }),
         load_builtin: false,
@@ -1293,12 +1295,14 @@ fn test_issue_1915_type_mismatch_in_child_still_errors() {
     let p = load_packages(&LoadPackageOptions {
         paths: vec!["test.k".to_string()],
         load_opts: Some(LoadProgramOptions {
-            k_code_list: vec![r#"
+            k_code_list: vec![
+                r#"
 schema Parent[value: str]:
 schema Child[value: bool, extra: str](Parent):
 child = Child("not_a_bool", "extra")
 "#
-            .to_string()],
+                .to_string(),
+            ],
             ..Default::default()
         }),
         load_builtin: false,
@@ -1357,7 +1361,8 @@ fn test_issue_1915_three_level_inheritance_default_values() {
     let p = load_packages(&LoadPackageOptions {
         paths: vec!["test.k".to_string()],
         load_opts: Some(LoadProgramOptions {
-            k_code_list: vec![r#"
+            k_code_list: vec![
+                r#"
 schema A[a: str = "a_default"]:
 schema B[a: int = 1](A):
 schema C[a: bool = True](B):
@@ -1365,7 +1370,8 @@ schema C[a: bool = True](B):
 
 c = C()
 "#
-            .to_string()],
+                .to_string(),
+            ],
             ..Default::default()
         }),
         load_builtin: false,

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -32,11 +32,13 @@ regex = "1.3"
 json-spanned-value = "0.2.2"
 compiler_base_span.workspace = true
 located_yaml = "0.2.1"
+ec4rs = "1.2"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
 criterion = "0.5"
 insta = "1.8.0"
+tempfile = "3.5.0"
 
 [[bench]]
 name = "benchmark"

--- a/crates/tools/src/format/editorconfig.rs
+++ b/crates/tools/src/format/editorconfig.rs
@@ -1,0 +1,280 @@
+//! Resolve a `kcl_ast_pretty::Config` for a file path by consulting
+//! `.editorconfig` (EditorConfig, https://editorconfig.org/) when present.
+//!
+//! Precedence (highest first):
+//!   1. Explicit `FormatOptions` fields (`use_spaces`, `indent_width`).
+//!   2. Matching section in the closest `.editorconfig` walking up from the file.
+//!   3. `kcl_ast_pretty::Config::default()` (4 spaces).
+//!
+//! This module does NOT modify `Config`'s `tab_len` semantics: when
+//! `indent_style = tab`, the printer emits one TAB per indent level regardless
+//! of `tab_len`. `tab_len` is only updated to reflect the EditorConfig
+//! `tab_width` for callers that want it as a display hint.
+
+use std::path::Path;
+
+use ec4rs::property::{IndentSize, IndentStyle, TabWidth};
+use kcl_ast_pretty::Config;
+
+use super::FormatOptions;
+
+/// Build the printer `Config` to use for `file_path`, honoring the explicit
+/// `FormatOptions` overrides plus any matching `.editorconfig`.
+pub(crate) fn resolve_config(file_path: &str, opts: &FormatOptions) -> Config {
+    let mut cfg = Config::default();
+    if should_discover(file_path) {
+        apply_editorconfig(&mut cfg, Path::new(file_path));
+    }
+    if let Some(use_spaces) = opts.use_spaces {
+        cfg.use_spaces = use_spaces;
+    }
+    if let Some(w) = opts.indent_width {
+        if w > 0 {
+            cfg.indent_len = w;
+        }
+    }
+    cfg
+}
+
+/// Guard against `ec4rs::properties_of("")` walking from CWD: only consult
+/// `.editorconfig` when the path actually points to a real file on disk.
+fn should_discover(file_path: &str) -> bool {
+    !file_path.is_empty() && Path::new(file_path).is_file()
+}
+
+fn apply_editorconfig(cfg: &mut Config, path: &Path) {
+    // properties_of returns Err on malformed/IO issues — silently fall back.
+    let Ok(mut props) = ec4rs::properties_of(path) else {
+        return;
+    };
+    // Per the EditorConfig spec, this fills in tab_width / indent_size
+    // defaults from each other when one is unset.
+    props.use_fallbacks();
+
+    if let Ok(style) = props.get::<IndentStyle>() {
+        cfg.use_spaces = matches!(style, IndentStyle::Spaces);
+    }
+
+    // indent_size takes priority over tab_width.
+    match props.get::<IndentSize>() {
+        Ok(IndentSize::Value(n)) if n > 0 => {
+            cfg.indent_len = n;
+        }
+        Ok(IndentSize::UseTabWidth) => {
+            if let Ok(TabWidth::Value(n)) = props.get::<TabWidth>() {
+                if n > 0 {
+                    cfg.indent_len = n;
+                    cfg.tab_len = n;
+                }
+            }
+        }
+        _ => {}
+    }
+
+    // tab_width is a *display* hint. Update only when the printer is in
+    // tab mode — in space mode `tab_len` is unused (see `fill`).
+    if !cfg.use_spaces {
+        if let Ok(TabWidth::Value(n)) = props.get::<TabWidth>() {
+            if n > 0 {
+                cfg.tab_len = n;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn opts() -> FormatOptions {
+        FormatOptions::default()
+    }
+
+    /// Write an .editorconfig to `dir/.editorconfig` with `root = true` so the
+    /// walk cannot escape the temp directory and contaminate other tests.
+    fn write_ec(dir: &Path, body: &str) {
+        let mut full = String::from("root = true\n\n");
+        full.push_str(body);
+        fs::write(dir.join(".editorconfig"), full).unwrap();
+    }
+
+    /// Create a fresh `.k` file at `dir/path` with `contents`.
+    fn write_k(dir: &Path, path: &str, contents: &str) -> std::path::PathBuf {
+        let p = dir.join(path);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&p, contents).unwrap();
+        p
+    }
+
+    #[test]
+    fn no_editorconfig_uses_defaults() {
+        let dir = TempDir::new().unwrap();
+        let k = write_k(dir.path(), "a.k", "x = 1\n");
+        let cfg = resolve_config(k.to_str().unwrap(), &opts());
+        assert_eq!(
+            cfg,
+            Config::default(),
+            "without .editorconfig we must use defaults"
+        );
+    }
+
+    #[test]
+    fn space_indent_size_two() {
+        let dir = TempDir::new().unwrap();
+        write_ec(dir.path(), "[*.k]\nindent_style = space\nindent_size = 2\n");
+        let k = write_k(dir.path(), "a.k", "x = 1\n");
+        let cfg = resolve_config(k.to_str().unwrap(), &opts());
+        assert!(cfg.use_spaces);
+        assert_eq!(cfg.indent_len, 2);
+    }
+
+    #[test]
+    fn tab_indent_style() {
+        let dir = TempDir::new().unwrap();
+        write_ec(dir.path(), "[*.k]\nindent_style = tab\n");
+        let k = write_k(dir.path(), "a.k", "x = 1\n");
+        let cfg = resolve_config(k.to_str().unwrap(), &opts());
+        assert!(!cfg.use_spaces, "tab indent_style must flip use_spaces");
+    }
+
+    #[test]
+    fn indent_size_overrides_tab_width() {
+        let dir = TempDir::new().unwrap();
+        write_ec(
+            dir.path(),
+            "[*.k]\nindent_style = space\nindent_size = 4\ntab_width = 8\n",
+        );
+        let k = write_k(dir.path(), "a.k", "x = 1\n");
+        let cfg = resolve_config(k.to_str().unwrap(), &opts());
+        assert_eq!(cfg.indent_len, 4, "indent_size wins over tab_width");
+    }
+
+    #[test]
+    fn indent_size_tab_falls_back_to_tab_width() {
+        let dir = TempDir::new().unwrap();
+        write_ec(
+            dir.path(),
+            "[*.k]\nindent_style = space\nindent_size = tab\ntab_width = 6\n",
+        );
+        let k = write_k(dir.path(), "a.k", "x = 1\n");
+        let cfg = resolve_config(k.to_str().unwrap(), &opts());
+        assert_eq!(
+            cfg.indent_len, 6,
+            "indent_size = tab must fall back to tab_width"
+        );
+    }
+
+    #[test]
+    fn parent_editorconfig_applies_to_nested_file() {
+        let dir = TempDir::new().unwrap();
+        write_ec(dir.path(), "[*.k]\nindent_size = 2\n");
+        let nested = dir.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        let k = write_k(&nested, "deep.k", "x = 1\n");
+        let cfg = resolve_config(k.to_str().unwrap(), &opts());
+        assert_eq!(cfg.indent_len, 2);
+    }
+
+    #[test]
+    fn nearest_editorconfig_wins() {
+        let dir = TempDir::new().unwrap();
+        write_ec(dir.path(), "[*.k]\nindent_size = 2\n");
+        let sub = dir.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+        write_ec(&sub, "[*.k]\nindent_size = 8\n");
+        let k = write_k(&sub, "a.k", "x = 1\n");
+        let cfg = resolve_config(k.to_str().unwrap(), &opts());
+        assert_eq!(cfg.indent_len, 8, "the closer .editorconfig must win");
+    }
+
+    #[test]
+    fn root_true_stops_parent_lookup() {
+        // Parent dir has indent_size = 2, child dir declares root = true and
+        // indent_size = 6. The walk must stop at the child.
+        let dir = TempDir::new().unwrap();
+        write_ec(dir.path(), "[*.k]\nindent_size = 2\n");
+        let child = dir.path().join("child");
+        fs::create_dir(&child).unwrap();
+        write_ec(&child, "[*.k]\nindent_size = 6\n");
+        let k = write_k(&child, "a.k", "x = 1\n");
+        let cfg = resolve_config(k.to_str().unwrap(), &opts());
+        assert_eq!(cfg.indent_len, 6);
+    }
+
+    #[test]
+    fn format_options_overrides_editorconfig() {
+        let dir = TempDir::new().unwrap();
+        write_ec(dir.path(), "[*.k]\nindent_size = 2\n");
+        let k = write_k(dir.path(), "a.k", "x = 1\n");
+        let mut o = FormatOptions::default();
+        o.indent_width = Some(8);
+        let cfg = resolve_config(k.to_str().unwrap(), &o);
+        assert_eq!(cfg.indent_len, 8, "explicit FormatOptions must win");
+    }
+
+    #[test]
+    fn use_spaces_override_flips_style() {
+        let dir = TempDir::new().unwrap();
+        write_ec(dir.path(), "[*.k]\nindent_style = tab\nindent_size = 4\n");
+        let k = write_k(dir.path(), "a.k", "x = 1\n");
+        let mut o = FormatOptions::default();
+        o.use_spaces = Some(true);
+        let cfg = resolve_config(k.to_str().unwrap(), &o);
+        assert!(
+            cfg.use_spaces,
+            "explicit use_spaces must override .editorconfig"
+        );
+    }
+
+    #[test]
+    fn non_matching_section_is_ignored() {
+        let dir = TempDir::new().unwrap();
+        // .editorconfig exists, but only has a [*.py] section. The KCL file
+        // must still get defaults.
+        write_ec(dir.path(), "[*.py]\nindent_size = 2\n");
+        let k = write_k(dir.path(), "a.k", "x = 1\n");
+        let cfg = resolve_config(k.to_str().unwrap(), &opts());
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn empty_path_skips_discovery() {
+        // Guard: ec4rs::properties_of("") would walk from CWD and silently
+        // inherit any .editorconfig above the server's working directory.
+        let cfg = resolve_config("", &opts());
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn nonexistent_path_skips_discovery() {
+        let dir = TempDir::new().unwrap();
+        // No file is created — the path must not cause a walk from CWD.
+        let bogus = dir.path().join("does_not_exist.k");
+        let cfg = resolve_config(bogus.to_str().unwrap(), &opts());
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn malformed_editorconfig_is_ignored_without_panic() {
+        let dir = TempDir::new().unwrap();
+        // Not a valid EditorConfig file at all.
+        fs::write(
+            dir.path().join(".editorconfig"),
+            "this is not valid !!! editorconfig content [[[",
+        )
+        .unwrap();
+        let k = write_k(dir.path(), "a.k", "x = 1\n");
+        let cfg = resolve_config(k.to_str().unwrap(), &opts());
+        // We don't care exactly which defaults survive — only that we don't
+        // panic and don't crash the formatter.
+        assert_eq!(cfg.indent_len, Config::default().indent_len);
+    }
+}

--- a/crates/tools/src/format/mod.rs
+++ b/crates/tools/src/format/mod.rs
@@ -6,11 +6,13 @@
 //! AST Module, and then use the AST printer [kcl_tools::printer::print_ast_module]
 //! to print it as source code string.
 use anyhow::Result;
-use kcl_ast_pretty::print_ast_module;
+use kcl_ast_pretty::print_ast_module_with_config;
 use kcl_parser::get_kcl_files;
 use std::path::Path;
 
 use kcl_parser::{parse_file_force_errors, parse_single_file};
+
+mod editorconfig;
 
 #[cfg(test)]
 mod tests;
@@ -20,12 +22,19 @@ mod tests;
 /// - recursively: whether to recursively traverse a folder and format all KCL files in it.
 /// - omit_errors: whether to omit the parse errors when format the KCL code.
 /// - dry_run: whether to return the filenames that would be formatted rather than format them.
+/// - use_spaces: override the `.editorconfig` `indent_style`. `Some(true)` emits
+///   spaces, `Some(false)` emits a single TAB per indent level. `None` lets
+///   `.editorconfig` decide (or the default if no `.editorconfig` applies).
+/// - indent_width: override the `.editorconfig` `indent_size`/`tab_width`.
+///   Ignored when `Some(0)` is passed.
 #[derive(Debug, Default)]
 pub struct FormatOptions {
     pub is_stdout: bool,
     pub recursively: bool,
     pub omit_errors: bool,
     pub dry_run: bool,
+    pub use_spaces: Option<bool>,
+    pub indent_width: Option<usize>,
 }
 
 /// Formats kcl file or directory path contains kcl files and
@@ -90,7 +99,10 @@ pub fn format_source(file: &str, src: &str, opts: &FormatOptions) -> Result<(Str
     } else {
         parse_file_force_errors(file, Some(src.to_string()))?
     };
-    let formatted_src = print_ast_module(&module);
+    // Resolve per file so directory walks can span subtrees with different
+    // `.editorconfig` files.
+    let cfg = editorconfig::resolve_config(file, opts);
+    let formatted_src = print_ast_module_with_config(&module, cfg);
     let is_formatted = src != formatted_src;
     Ok((formatted_src, is_formatted))
 }

--- a/crates/tools/src/format/test_data/.editorconfig
+++ b/crates/tools/src/format/test_data/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.k]
+indent_style = space
+indent_size = 4

--- a/crates/tools/src/format/tests.rs
+++ b/crates/tools/src/format/tests.rs
@@ -300,3 +300,80 @@ fn test_format_trailing_newlines() {
         var_trailing
     );
 }
+
+// ---------------------------------------------------------------------------
+// .editorconfig end-to-end tests
+// ---------------------------------------------------------------------------
+
+mod editorconfig_e2e {
+    use std::fs;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Helper: write an `.editorconfig` with `root = true` so the walk
+    /// cannot escape the temp directory.
+    fn write_ec(dir: &std::path::Path, body: &str) {
+        let mut full = String::from("root = true\n\n");
+        full.push_str(body);
+        fs::write(dir.join(".editorconfig"), full).unwrap();
+    }
+
+    #[test]
+    fn editorconfig_two_space_indent() {
+        let dir = TempDir::new().unwrap();
+        write_ec(dir.path(), "[*.k]\nindent_style = space\nindent_size = 2\n");
+        let k = dir.path().join("sample.k");
+        fs::write(&k, "x = {\n    a: {\n        b: 1\n    }\n}\n").unwrap();
+
+        let src = std::fs::read_to_string(&k).unwrap();
+        let (formatted, _) =
+            format_source(k.to_str().unwrap(), &src, &FormatOptions::default()).unwrap();
+
+        // Two-space indent from .editorconfig — every nested key gets 2 spaces.
+        assert!(
+            formatted.contains("  a: {\n    b: 1\n  }\n}"),
+            "expected 2-space indent from .editorconfig, got:\n{formatted}"
+        );
+    }
+
+    #[test]
+    fn editorconfig_tab_indent_style() {
+        let dir = TempDir::new().unwrap();
+        write_ec(dir.path(), "[*.k]\nindent_style = tab\n");
+        let k = dir.path().join("sample.k");
+        fs::write(&k, "x = {\n    a: {\n        b: 1\n    }\n}\n").unwrap();
+
+        let src = std::fs::read_to_string(&k).unwrap();
+        let (formatted, _) =
+            format_source(k.to_str().unwrap(), &src, &FormatOptions::default()).unwrap();
+
+        // Tab mode emits one TAB per indent level regardless of indent_len.
+        assert!(
+            formatted.contains("\n\ta: {\n\t\tb: 1\n\t}\n}\n"),
+            "expected TAB indent from .editorconfig, got:\n{formatted}"
+        );
+    }
+
+    #[test]
+    fn format_options_override_editorconfig() {
+        let dir = TempDir::new().unwrap();
+        write_ec(dir.path(), "[*.k]\nindent_style = space\nindent_size = 8\n");
+        let k = dir.path().join("sample.k");
+        fs::write(&k, "x = {\n    a: 1\n}\n").unwrap();
+
+        let src = std::fs::read_to_string(&k).unwrap();
+        // Override: ask for 2-space indent regardless of what the file's
+        // .editorconfig says.
+        let opts = FormatOptions {
+            indent_width: Some(2),
+            ..FormatOptions::default()
+        };
+        let (formatted, _) = format_source(k.to_str().unwrap(), &src, &opts).unwrap();
+
+        assert!(
+            formatted.contains("  a: 1\n}\n"),
+            "expected explicit 2-space override, got:\n{formatted}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Part of #1930. Implements the **indentation subset** of `.editorconfig`
support: `indent_style`, `indent_size`, and `tab_width`. Other
`.editorconfig` properties (e.g. `end_of_line`, `insert_final_newline`,
`max_line_length`, `charset`) are intentionally out of scope for this PR
and remain tracked under #1930.

Precedence (highest first):

1. Explicit `FormatOptions` fields (`use_spaces`, `indent_width`)
2. Matching section in the closest `.editorconfig`
3. Defaults (4 spaces)

## Changes

| File | Change |
|---|---|
| `crates/tools/Cargo.toml` | Add `ec4rs = "1.2"`; add `tempfile = "3.5.0"` to dev-dependencies |
| `crates/ast_pretty/src/lib.rs` | Derive `Clone, PartialEq, Eq` on `Config`; add `print_ast_module_with_config` |
| `crates/ast_pretty/src/tests.rs` | +4 tests for the new entrypoint and tab-mode semantics |
| `crates/tools/src/format/editorconfig.rs` | New module: `resolve_config`, `should_discover`, `apply_editorconfig` + 13 unit tests |
| `crates/tools/src/format/mod.rs` | Add `use_spaces: Option<bool>` and `indent_width: Option<usize>` to `FormatOptions`; resolve per-file in `format_source` |
| `crates/tools/src/format/tests.rs` | +3 end-to-end tempdir tests |
| `crates/tools/src/format/test_data/.editorconfig` | Pin fixture so existing golden tests stay stable |
| `crates/api/src/service/service_impl.rs` | Add `..Default::default()` to the `FormatOptions` literal |

## Non-obvious correctness points

- **`fill` is left alone.** `indent_style = tab` means one TAB per indent
  level; `tab_width` is a *display* hint per the EditorConfig spec, not
  bytes. Changing `TAB.repeat(self.indent)` to use `tab_len` spaces would
  break spec compliance.
- **CWD escape guard.** `ec4rs::properties_of("")` would walk from CWD.
  `should_discover` requires a real file path, so empty/`""` paths skip
  discovery. `format_code` (which passes `""` for the path) is unaffected.
- **Per-file resolution.** `format_source` resolves the `Config` per file
  so directory walks can span subtrees with different `.editorconfig` files.
- **Proto unchanged.** Discovery happens server-side from the path. LSP
  already calls `format_source(&file, …)` with a real filesystem path so
  discovery is automatic.

## Follow-ups (still tracked under #1930)

- `end_of_line` (LF / CRLF)
- `insert_final_newline` / `trim_trailing_whitespace`
- `max_line_length` (line wrapping / reflow)
- `charset`

These will require both a formatter-side change and potentially a
follow-up wire-compat proto discussion for `format_code`, which currently
passes `""` as the path.

## Test plan

- [x] `cargo test -p kcl-ast-pretty` (5 tests)
- [x] `cargo test -p kcl-tools format::` (25 tests, all pass; existing
      golden files unchanged)
- [x] `cargo test -p kcl-api --doc format` (2 doc tests)
- [x] `cargo test -p kcl-language-server --lib formatting` (4 tests)
- [x] `cargo build -p kcl-ast-pretty -p kcl-tools -p kcl-api` succeeds
- [x] `cargo clippy` clean on affected crates (no new warnings)
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)