### PR TITLE
fix(vet): load sibling .k files when validating inside a kcl.mod package

### DIFF
--- a/crates/evaluator/src/node.rs
+++ b/crates/evaluator/src/node.rs
@@ -1590,8 +1590,12 @@ impl<'ctx> Evaluator<'ctx> {
                 };
                 if !skip_type_check {
                     if let Some(ty) = arg_type {
-                        arg_value =
-                            type_pack_and_check(self, &arg_value, vec![&ty.node.to_string()], false);
+                        arg_value = type_pack_and_check(
+                            self,
+                            &arg_value,
+                            vec![&ty.node.to_string()],
+                            false,
+                        );
                     }
                 }
                 // Mark positional argument as a local variable
@@ -1610,8 +1614,12 @@ impl<'ctx> Evaluator<'ctx> {
                 // Type check keyword arguments if type annotation is present
                 if !skip_type_check {
                     if let Some(ty) = arg_type {
-                        arg_value =
-                            type_pack_and_check(self, &arg_value, vec![&ty.node.to_string()], false);
+                        arg_value = type_pack_and_check(
+                            self,
+                            &arg_value,
+                            vec![&ty.node.to_string()],
+                            false,
+                        );
                     }
                 }
                 // Mark keyword argument as a local variable

--- a/crates/evaluator/src/tests.rs
+++ b/crates/evaluator/src/tests.rs
@@ -1218,7 +1218,8 @@ fn test_issue_1915_child_schema_arg_overrides_parent_type() {
     let p = load_packages(&LoadPackageOptions {
         paths: vec!["test.k".to_string()],
         load_opts: Some(LoadProgramOptions {
-            k_code_list: vec![r#"
+            k_code_list: vec![
+                r#"
 schema Parent[value: str]:
 schema Child[value: bool, extra: str](Parent):
     valueAttr: bool = value
@@ -1228,7 +1229,8 @@ positional = Child(True, "p")
 keyword = Child(value=False, extra="k")
 caller_keyword = Child(False, "c")
 "#
-            .to_string()],
+                .to_string(),
+            ],
             ..Default::default()
         }),
         load_builtin: false,
@@ -1293,12 +1295,14 @@ fn test_issue_1915_type_mismatch_in_child_still_errors() {
     let p = load_packages(&LoadPackageOptions {
         paths: vec!["test.k".to_string()],
         load_opts: Some(LoadProgramOptions {
-            k_code_list: vec![r#"
+            k_code_list: vec![
+                r#"
 schema Parent[value: str]:
 schema Child[value: bool, extra: str](Parent):
 child = Child("not_a_bool", "extra")
 "#
-            .to_string()],
+                .to_string(),
+            ],
             ..Default::default()
         }),
         load_builtin: false,
@@ -1357,7 +1361,8 @@ fn test_issue_1915_three_level_inheritance_default_values() {
     let p = load_packages(&LoadPackageOptions {
         paths: vec!["test.k".to_string()],
         load_opts: Some(LoadProgramOptions {
-            k_code_list: vec![r#"
+            k_code_list: vec![
+                r#"
 schema A[a: str = "a_default"]:
 schema B[a: int = 1](A):
 schema C[a: bool = True](B):
@@ -1365,7 +1370,8 @@ schema C[a: bool = True](B):
 
 c = C()
 "#
-            .to_string()],
+                .to_string(),
+            ],
             ..Default::default()
         }),
         load_builtin: false,

--- a/crates/tools/src/vet/test_datas/validate_cases/pkg_with_kcl_mod/kcl.mod
+++ b/crates/tools/src/vet/test_datas/validate_cases/pkg_with_kcl_mod/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "pkg_with_kcl_mod"
+edition = "v0.11.0"
+version = "0.0.1"

--- a/crates/tools/src/vet/test_datas/validate_cases/pkg_with_kcl_mod/name.k
+++ b/crates/tools/src/vet/test_datas/validate_cases/pkg_with_kcl_mod/name.k
@@ -1,0 +1,2 @@
+schema Name:
+    fullName: str

--- a/crates/tools/src/vet/test_datas/validate_cases/pkg_with_kcl_mod/person.k
+++ b/crates/tools/src/vet/test_datas/validate_cases/pkg_with_kcl_mod/person.k
@@ -1,0 +1,6 @@
+schema Person:
+    name: Name
+    age: int
+
+    check:
+        0 < age < 120

--- a/crates/tools/src/vet/test_datas/validate_cases/pkg_with_kcl_mod/person.k.json
+++ b/crates/tools/src/vet/test_datas/validate_cases/pkg_with_kcl_mod/person.k.json
@@ -1,0 +1,6 @@
+{
+    "name": {
+        "fullName": "Alice"
+    },
+    "age": 30
+}

--- a/crates/tools/src/vet/test_datas/validate_cases/pkg_with_kcl_mod/person.k.yaml
+++ b/crates/tools/src/vet/test_datas/validate_cases/pkg_with_kcl_mod/person.k.yaml
@@ -1,0 +1,3 @@
+name:
+  fullName: "Alice"
+age: 30

--- a/crates/tools/src/vet/tests.rs
+++ b/crates/tools/src/vet/tests.rs
@@ -355,6 +355,10 @@ mod test_validater {
         println!("test_validate_with_invalid_file_path - PASS");
         test_validate_with_invalid_file_type();
         println!("test_validate_with_invalid_file_type - PASS");
+        test_validate_with_pkg_with_kcl_mod();
+        println!("test_validate_with_pkg_with_kcl_mod - PASS");
+        test_validate_without_kcl_mod_keeps_single_file_behavior();
+        println!("test_validate_without_kcl_mod_keeps_single_file_behavior - PASS");
         test_invalid_validate_with_json_pos();
         println!("test_invalid_validate_with_json_pos - PASS");
         test_invalid_validate_with_yaml_pos();
@@ -400,6 +404,86 @@ mod test_validater {
                     err, validated_file_path
                 ),
             }
+        }
+    }
+
+    /// Regression test for https://github.com/kcl-lang/kcl/issues/1877.
+    ///
+    /// When a schema lives in a KCL package (a directory containing a
+    /// `kcl.mod`) and references another schema declared in a sibling
+    /// file without an explicit `import`, `kcl vet` used to fail with
+    /// `Cannot find the module` because only the single file passed on
+    /// the command line was loaded. After the fix, all sibling `.k`
+    /// files in the same package directory are loaded so cross-file
+    /// schema references resolve correctly.
+    fn test_validate_with_pkg_with_kcl_mod() {
+        for (i, file_suffix) in VALIDATED_FILE_TYPE.iter().enumerate() {
+            let validated_file_path = construct_full_path(&format!(
+                "{}.{}",
+                Path::new("validate_cases")
+                    .join("pkg_with_kcl_mod")
+                    .join("person.k")
+                    .display(),
+                file_suffix
+            ))
+            .unwrap();
+
+            let kcl_file_path = construct_full_path(
+                &Path::new("validate_cases")
+                    .join("pkg_with_kcl_mod")
+                    .join("person.k")
+                    .display()
+                    .to_string(),
+            )
+            .unwrap();
+
+            let opt = ValidateOption::new(
+                Some("Person".to_string()),
+                "value".to_string(),
+                validated_file_path.clone(),
+                *LOADER_KIND[i],
+                Some(kcl_file_path.to_string()),
+                None,
+                Default::default(),
+            );
+
+            match validate(opt) {
+                Ok(res) => assert!(
+                    res,
+                    "pkg_with_kcl_mod validation should succeed (cross-file schema reference)"
+                ),
+                Err(err) => panic!(
+                    "pkg_with_kcl_mod validation failed: {:?}\nvalidated_file: {}",
+                    err, validated_file_path
+                ),
+            }
+        }
+    }
+
+    /// Regression test for the historical "single file" behaviour of
+    /// `kcl vet` outside of declared KCL packages.
+    ///
+    /// Without a `kcl.mod` in the directory, neighbouring `.k` files in
+    /// `validate_cases/` (each declaring its own `schema User` for
+    /// unrelated test scenarios) must NOT be pulled in. Loading them
+    /// would cause spurious "Unique key error" failures.
+    fn test_validate_without_kcl_mod_keeps_single_file_behavior() {
+        let validated_file_path = construct_full_path("validate_cases/test.k.json").unwrap();
+        let kcl_file_path = construct_full_path("validate_cases/test.k").unwrap();
+
+        let opt = ValidateOption::new(
+            None,
+            "value".to_string(),
+            validated_file_path,
+            LoaderKind::JSON,
+            Some(kcl_file_path),
+            None,
+            Default::default(),
+        );
+
+        match validate(opt) {
+            Ok(res) => assert!(res, "validate_cases/test.k validation should still succeed"),
+            Err(err) => panic!("validate_cases/test.k validation failed: {:?}", err),
         }
     }
 

--- a/crates/tools/src/vet/validator.rs
+++ b/crates/tools/src/vet/validator.rs
@@ -74,6 +74,7 @@ use kcl_ast::{
     ast::{AssignStmt, Expr, Node, NodeRef, Program, SchemaStmt, Stmt, Target},
     node_ref,
 };
+use kcl_config::modfile::{KCL_FILE_SUFFIX, KCL_MOD_FILE, get_pkg_root};
 use kcl_parser::{LoadProgramOptions, ParseSessionRef};
 use kcl_runner::{ExecProgramArgs, MapErrorResult, execute};
 
@@ -180,9 +181,15 @@ pub fn validate(val_opt: ValidateOption) -> Result<bool> {
     let k_code = val_opt.kcl_code.map_or_else(Vec::new, |code| vec![code]);
 
     let sess = ParseSessionRef::default();
+    // Expand a single file path to the full set of `.k` files in its
+    // surrounding package directory. This makes `kcl vet` resolve schema
+    // references across sibling files in the same package (e.g. `a.k`
+    // referring to a schema declared in `b.k` without an explicit `import`)
+    // and lets `kcl.mod` drive vendor-cache lookup for external packages.
+    let k_paths = expand_kcl_path(&k_path)?;
     let compile_res = kcl_parser::load_program(
         sess,
-        [k_path]
+        k_paths
             .iter()
             .map(|s| s.as_str())
             .collect::<Vec<&str>>()
@@ -265,6 +272,93 @@ fn filter_schema_stmt_from_prog(prog: &Program) -> Vec<SchemaStmt> {
     }
 
     result
+}
+
+/// Expand a single KCL file path into the list of files that should be
+/// handed to the loader. When the path points to a regular `.k` file
+/// inside a directory that declares itself as a KCL package via a
+/// `kcl.mod`, we return every loadable sibling `.k` file in that
+/// package directory so that:
+///
+/// - schema references across sibling files inside the same package
+///   (e.g. `a.k` referring to a schema declared in `b.k` without an
+///   explicit `import`) resolve during validation; and
+/// - `kcl.mod` entries can drive vendor-cache lookup for external
+///   packages declared in `[dependencies]`.
+///
+/// The function returns a single-element vector containing the original
+/// path unchanged in every other case, to preserve historical behaviour
+/// for inputs that are not part of a declared KCL package:
+///
+/// - the path is empty,
+/// - the path is the synthetic `TMP_FILE` placeholder used when only
+///   `kcl_code` is supplied,
+/// - the path does not refer to an existing file,
+/// - the file has no detectable package root (e.g. it lives outside the
+///   filesystem),
+/// - the resolved package root is not a directory, or
+/// - the resolved package root does not contain a `kcl.mod` file. In
+///   that case we keep the historical "single file" behaviour, because
+///   neighbouring `.k` files in a flat directory are typically unrelated
+///   ad-hoc schemas and including them would cause spurious
+///   duplicate-definition errors.
+fn expand_kcl_path(path: &str) -> Result<Vec<String>> {
+    if path.is_empty() || path == TMP_FILE {
+        return Ok(vec![path.to_string()]);
+    }
+
+    let p = std::path::Path::new(path);
+    if !p.is_file() {
+        return Ok(vec![path.to_string()]);
+    }
+
+    let pkg_root = match get_pkg_root(path) {
+        Some(root) => root,
+        None => return Ok(vec![path.to_string()]),
+    };
+
+    let pkg_root_path = std::path::Path::new(&pkg_root);
+    if !pkg_root_path.is_dir() {
+        return Ok(vec![path.to_string()]);
+    }
+
+    // Only treat the surrounding directory as a package if it actually
+    // declares itself with a `kcl.mod`. Without that marker, sibling
+    // files are typically unrelated ad-hoc schemas and including them
+    // would cause spurious duplicate-definition errors.
+    if !pkg_root_path.join(KCL_MOD_FILE).is_file() {
+        return Ok(vec![path.to_string()]);
+    }
+
+    let mut files: Vec<String> = Vec::new();
+    for entry in std::fs::read_dir(pkg_root_path)
+        .map_err(|e| anyhow::anyhow!("Failed to read package directory '{}': {}", pkg_root, e))?
+    {
+        let entry = entry?;
+        let entry_path = entry.path();
+        if !entry_path.is_file() {
+            continue;
+        }
+        // Skip non-KCL files, hidden files, and KCL test files.
+        let name = match entry_path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if name.starts_with('_') || !name.ends_with(KCL_FILE_SUFFIX) {
+            continue;
+        }
+        if let Ok(canonical) = entry_path.canonicalize() {
+            files.push(canonical.to_string_lossy().to_string());
+        } else {
+            files.push(entry_path.to_string_lossy().to_string());
+        }
+    }
+    files.sort();
+
+    if files.is_empty() {
+        return Ok(vec![path.to_string()]);
+    }
+    Ok(files)
 }
 
 pub struct ValidateOption {


### PR DESCRIPTION
## Summary

`kcl vet` only loaded the single file passed on the command line, so schemas
that referenced another schema declared in a sibling file inside the same
package failed validation with `Cannot find the module`, and `kcl.mod`
`[dependencies]` could not drive vendor-cache lookup for external packages.

When the file lives in a directory that declares itself as a KCL package via
`kcl.mod`, expand the input to every loadable sibling `.k` file in that
package directory (skipping hidden files and `_*` test files) and hand the
lot to `kcl_parser::load_program`. For every other case — empty path, the
`TMP_FILE` placeholder, non-existent files, files without a detectable
package root, or package roots without a `kcl.mod` — keep the historical
"single file" behaviour so unrelated `.k` files in a flat directory are not
pulled in (which would otherwise cause spurious `Unique key error` failures
when neighbouring tests share a `schema User` declaration).

## Companion PRs

This is the Rust core half of the fix; the Go SDK and CLI counterparts are
upstream separately:

- kcl-lang/kcl-go#566 — `ValidateOptions.ExternalPackages`
- kcl-lang/cli#365 — `kcl vet -E/--external` flag

## Tests

- New regression test `test_validate_with_pkg_with_kcl_mod` exercises the
  cross-file schema reference path with a freshly added package under
  `crates/tools/src/vet/test_datas/validate_cases/pkg_with_kcl_mod/`.
- New regression test `test_validate_without_kcl_mod_keeps_single_file_behavior`
  pins down the historical single-file behaviour for directories without a
  `kcl.mod`, ensuring we do not regress unrelated test fixtures.

## Fixes

https://github.com/kcl-lang/kcl/issues/1877

## Checklist

- [x] Signed-off-by trailer present
- [ ] CI green (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)