### PR TITLE
fix(resolver): pre-scan top-level lambdas for forward reference type checking

### DIFF
--- a/crates/sema/src/resolver/global.rs
+++ b/crates/sema/src/resolver/global.rs
@@ -17,6 +17,12 @@ use super::doc::{SchemaDoc, parse_schema_doc_string};
 use super::scope::{ScopeObject, ScopeObjectKind};
 use kcl_ast::pos::GetPos;
 
+/// Sentinel used in `init_global_lambda_types` to mark names whose
+/// declaration is reassigned (e.g. `f = lambda...; f = 1`). Reassignment
+/// drops the lambda signature from the side table so the pre-scan does
+/// not type-check calls against a stale function type.
+const NO_LAMBDA: Option<FunctionType> = None;
+
 const MAX_SCOPE_SCAN_COUNT: usize = 3;
 pub const MIXIN_SUFFIX: &str = "Mixin";
 pub const PROTOCOL_SUFFIX: &str = "Protocol";
@@ -188,7 +194,88 @@ impl<'ctx> Resolver<'_> {
             }
             // 2.  Build all variable types
             self.init_global_var_types(false);
+            // 4. Record the signatures of the top level lambda globals.
+            self.init_global_lambda_types();
         }
+    }
+
+    /// Pre-scan top-level direct `AssignStmt`s whose RHS is a lambda and
+    /// record a provisional `FunctionType` (parsed parameter types + an
+    /// `any` return) under the assigned name in
+    /// `Context::global_lambda_tys`. This is the counterpart of the
+    /// schema pre-scan: top-level globals are evaluated at runtime in
+    /// declaration-order-independent fashion, but the source-order type
+    /// walker sees them in text order, which causes forward references
+    /// to a lambda to fail argument type-checking (`E2G22`). See issue
+    /// kcl-lang/kcl#1725.
+    ///
+    /// Scope: only direct top-level single-target unannotated `AssignStmt`s
+    /// are processed, exactly the same conditions under which globals are
+    /// order-independent at runtime. Reassignments drop the prior
+    /// signature. The lambda body and defaults are NOT walked during the
+    /// pre-scan — `walk_lambda_expr` still runs exactly once per lambda
+    /// during the main source-order walk and produces the normal body /
+    /// return diagnostics.
+    fn init_global_lambda_types(&mut self) {
+        let pkgpath = self.ctx.pkgpath.clone();
+        let Some(modules) = self
+            .program
+            .pkgs
+            .get(&pkgpath)
+            .or_else(|| self.program.pkgs_not_imported.get(&pkgpath))
+            .cloned()
+        else {
+            return;
+        };
+        let mut lambda_tys: IndexMap<String, Option<FunctionType>> = IndexMap::default();
+        for module in modules {
+            let module = self
+                .program
+                .get_module(&module)
+                .expect("Failed to acquire module lock")
+                .unwrap_or_else(|| panic!("module {:?} not found in program", module));
+            self.ctx.filename = module.filename.clone();
+            for stmt in &module.body {
+                let ast::Stmt::Assign(assign_stmt) = &stmt.node else {
+                    continue;
+                };
+                if assign_stmt.targets.len() != 1 {
+                    continue;
+                }
+                let target = &assign_stmt.targets[0];
+                if !target.node.paths.is_empty() {
+                    continue;
+                }
+                let name = target.node.get_name();
+                if lambda_tys.contains_key(name) {
+                    // A later assignment to the same name — drop any
+                    // prior lambda signature so we don't type-check
+                    // calls against a stale function type.
+                    lambda_tys.insert(name.to_string(), NO_LAMBDA);
+                    continue;
+                }
+                let lambda_ty = match (&assign_stmt.ty, &assign_stmt.value.node) {
+                    (None, ast::Expr::Lambda(lambda_expr)) => {
+                        let params = self.parse_lambda_params(lambda_expr);
+                        Some(FunctionType {
+                            doc: "".to_string(),
+                            params,
+                            self_ty: None,
+                            return_ty: self.any_ty(),
+                            is_variadic: false,
+                            kw_only_index: None,
+                        })
+                    }
+                    _ => NO_LAMBDA,
+                };
+                lambda_tys.insert(name.to_string(), lambda_ty);
+            }
+        }
+        let lambda_tys: IndexMap<String, FunctionType> = lambda_tys
+            .into_iter()
+            .filter_map(|(name, ty)| ty.map(|ty| (name, ty)))
+            .collect();
+        self.ctx.global_lambda_tys.insert(pkgpath, lambda_tys);
     }
 
     /// Init global var types.

--- a/crates/sema/src/resolver/mod.rs
+++ b/crates/sema/src/resolver/mod.rs
@@ -30,7 +30,7 @@ use crate::resolver::scope::ScopeObject;
 use crate::resolver::ty_alias::type_alias_pass;
 use crate::resolver::ty_erasure::type_func_erasure_pass;
 use crate::ty::TypeContext;
-use crate::{resolver::scope::Scope, ty::SchemaType};
+use crate::{resolver::scope::Scope, ty::FunctionType, ty::SchemaType};
 use kcl_ast::ast::Program;
 use kcl_error::*;
 
@@ -164,6 +164,13 @@ pub struct Context {
     pub invalid_pkg_scope: IndexSet<String>,
     /// Memoized parsed schema/rule doc strings, keyed by raw doc text.
     pub parsed_doc_cache: IndexMap<String, Arc<SchemaDoc>>,
+    /// Signatures of top-level lambda globals, used to type-check calls of
+    /// lambdas that are declared after the call site (issue #1725). Keyed
+    /// by package path, then by global name. Populated by
+    /// `init_global_lambda_types`; consulted by `walk_call_expr` when the
+    /// callee resolves to `any` (the default installed before the
+    /// lambda is processed in source order).
+    pub global_lambda_tys: IndexMap<String, IndexMap<String, FunctionType>>,
 }
 
 /// Resolve options.

--- a/crates/sema/src/resolver/node.rs
+++ b/crates/sema/src/resolver/node.rs
@@ -4,6 +4,7 @@ use kcl_ast::walker::MutSelfTypedResultWalker;
 use kcl_ast_pretty::{ASTNode, print_ast_node};
 use kcl_error::*;
 use kcl_primitives::IndexMap;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::info::is_private_field;
@@ -561,13 +562,59 @@ impl<'ctx> MutSelfTypedResultWalker<'ctx> for Resolver<'_> {
         let call_ty = self.expr(&call_expr.func);
         let range = call_expr.func.get_span_pos();
         if call_ty.is_any() {
-            self.do_arguments_type_check(
-                &call_expr.func,
-                &call_expr.args,
-                &call_expr.keywords,
-                &FunctionType::variadic_func(),
-            );
-            self.any_ty()
+            // Look up a provisional `FunctionType` for this call's
+            // callee when the callee is a bare identifier that resolves
+            // to a package-level global recorded in
+            // `Context::global_lambda_tys`. This lets forward references
+            // to top-level lambdas (declared after the call site, issue
+            // kcl-lang/kcl#1725) be type-checked against the lambda's
+            // declared parameter types instead of falling through to the
+            // variadic fallback. We require the resolved scope object to
+            // be the same `Rc` as the package-scope entry — verified via
+            // `Rc::ptr_eq` — so this branch only fires for package-level
+            // lambdas, never for nested closures or local variables that
+            // happen to share a name.
+            let global_lambda_ty = if let ast::Expr::Identifier(identifier) = &call_expr.func.node
+                && identifier.names.len() == 1
+                && identifier.pkgpath.is_empty()
+            {
+                let name = &identifier.names[0].node;
+                let package_obj = self
+                    .scope_map
+                    .get(&self.ctx.pkgpath)
+                    .and_then(|scope| scope.borrow().elems.get(name).cloned());
+                let resolved_obj = self.scope.borrow().lookup(name);
+                if let (Some(package_obj), Some(resolved_obj)) = (package_obj, resolved_obj)
+                    && Rc::ptr_eq(&package_obj, &resolved_obj)
+                {
+                    self.ctx
+                        .global_lambda_tys
+                        .get(&self.ctx.pkgpath)
+                        .and_then(|lambda_tys| lambda_tys.get(name))
+                        .cloned()
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            if let Some(func_ty) = global_lambda_ty {
+                self.do_arguments_type_check(
+                    &call_expr.func,
+                    &call_expr.args,
+                    &call_expr.keywords,
+                    &func_ty,
+                );
+                self.any_ty()
+            } else {
+                self.do_arguments_type_check(
+                    &call_expr.func,
+                    &call_expr.args,
+                    &call_expr.keywords,
+                    &FunctionType::variadic_func(),
+                );
+                self.any_ty()
+            }
         } else if let TypeKind::Function(func_ty) = &call_ty.kind {
             self.do_arguments_type_check(
                 &call_expr.func,
@@ -959,41 +1006,16 @@ impl<'ctx> MutSelfTypedResultWalker<'ctx> for Resolver<'_> {
 
     fn walk_lambda_expr(&mut self, lambda_expr: &'ctx ast::LambdaExpr) -> Self::Result {
         let mut ret_ty = self.any_ty();
-        let mut params = vec![];
         self.do_parameters_check(&lambda_expr.args);
+        let params = self.parse_lambda_params(lambda_expr);
         if let Some(args) = &lambda_expr.args {
             for (i, arg) in args.node.args.iter().enumerate() {
-                let name = arg.node.get_name();
-                let arg_ty = args.node.get_arg_type_node(i);
-                let range = match arg_ty {
-                    Some(arg_type_node) => arg_type_node.get_span_pos(),
-                    None => arg.get_span_pos(),
-                };
-                let ty = self.parse_ty_with_scope(arg_ty, range);
-
-                // If the arguments type of a lambda is a schema type,
-                // It should be marked as an schema instance type.
-                let ty = if let TypeKind::Schema(sty) = &ty.kind {
-                    let mut arg_ty = sty.clone();
-                    arg_ty.is_instance = true;
-                    Arc::new(Type::schema(arg_ty))
-                } else {
-                    ty.clone()
-                };
                 if let Some(name) = arg.node.names.last() {
                     self.node_ty_map
                         .borrow_mut()
-                        .insert(self.get_node_key(name.id.clone()), ty.clone());
+                        .insert(self.get_node_key(name.id.clone()), params[i].ty.clone());
                 }
-
                 let value = &args.node.defaults[i];
-                params.push(Parameter {
-                    name,
-                    ty: ty.clone(),
-                    has_default: value.is_some(),
-                    default_value: value.as_ref().map(|v| print_ast_node(ASTNode::Expr(v))),
-                    range: args.node.args[i].get_span_pos(),
-                });
                 self.expr_or_any_type(value);
             }
         }
@@ -1232,6 +1254,47 @@ impl<'ctx> MutSelfTypedResultWalker<'ctx> for Resolver<'_> {
 }
 
 impl<'ctx> Resolver<'_> {
+    /// Parse the parameter declarations of a lambda expression and return
+    /// them as a `Vec<Parameter>`. Used by both the global pre-scan
+    /// (`init_global_lambda_types`) and the regular `walk_lambda_expr`.
+    ///
+    /// This helper does NOT call `do_parameters_check` and does NOT walk
+    /// default-value expressions — both are validation passes that produce
+    /// diagnostics and are still performed exactly once by
+    /// `walk_lambda_expr`. Calling this from a pre-scan therefore cannot
+    /// produce duplicate diagnostics.
+    pub fn parse_lambda_params(&mut self, lambda_expr: &'ctx ast::LambdaExpr) -> Vec<Parameter> {
+        let mut params = vec![];
+        if let Some(args) = &lambda_expr.args {
+            for (i, arg) in args.node.args.iter().enumerate() {
+                let name = arg.node.get_name();
+                let arg_ty = args.node.get_arg_type_node(i);
+                let range = match arg_ty {
+                    Some(arg_type_node) => arg_type_node.get_span_pos(),
+                    None => arg.get_span_pos(),
+                };
+                let ty = self.parse_ty_with_scope(arg_ty, range);
+                // Match walk_lambda_expr: schema param annotations become instance types.
+                let ty = if let TypeKind::Schema(sty) = &ty.kind {
+                    let mut arg_ty = sty.clone();
+                    arg_ty.is_instance = true;
+                    Arc::new(Type::schema(arg_ty))
+                } else {
+                    ty
+                };
+                let value = &args.node.defaults[i];
+                params.push(Parameter {
+                    name,
+                    ty,
+                    has_default: value.is_some(),
+                    default_value: value.as_ref().map(|v| print_ast_node(ASTNode::Expr(v))),
+                    range: args.node.args[i].get_span_pos(),
+                });
+            }
+        }
+        params
+    }
+
     pub fn stmts(&mut self, stmts: &'ctx [ast::NodeRef<ast::Stmt>]) -> ResolvedResult {
         let stmt_types: Vec<TypeRef> = stmts.iter().map(|stmt| self.stmt(stmt)).collect();
         match stmt_types.last() {

--- a/crates/sema/src/resolver/test_fail_data/lambda_forward_reference.k
+++ b/crates/sema/src/resolver/test_fail_data/lambda_forward_reference.k
@@ -1,0 +1,11 @@
+_xs = {
+    "u" = ["XX-01"]
+}
+
+items = {
+    k: f(k, v) for k, v in _xs
+}
+
+f = lambda a: str, b: str -> str {
+    a + "/" + b
+}

--- a/crates/sema/src/resolver/tests.rs
+++ b/crates/sema/src/resolver/tests.rs
@@ -172,6 +172,7 @@ fn test_resolve_program_fail() {
         "lambda_schema_ty_1.k",
         "lambda_schema_ty_2.k",
         "lambda_schema_ty_3.k",
+        "lambda_forward_reference.k",
         "module_optional_select.k",
         "mutable_error_0.k",
         "mutable_error_1.k",

--- a/tests/grammar/lambda/lambda_forward_reference_type_check/main.k
+++ b/tests/grammar/lambda/lambda_forward_reference_type_check/main.k
@@ -1,0 +1,11 @@
+_xs = {
+    "u" = ["XX-01"]
+}
+
+items = {
+    k: f(k, v) for k, v in _xs
+}
+
+f = lambda a: str, b: str -> str {
+    a + "/" + b
+}

--- a/tests/grammar/lambda/lambda_forward_reference_type_check/stderr.golden
+++ b/tests/grammar/lambda/lambda_forward_reference_type_check/stderr.golden
@@ -1,0 +1,11 @@
+error[E2G22]: TypeError
+ --> ${CWD}/main.k:6:13
+  |
+6 |     k: f(k, v) for k, v in _xs
+  |             ^ expected str, got [str]
+  |
+ --> ${CWD}/main.k:9:20
+  |
+9 | f = lambda a: str, b: str -> str {
+  |                    ^ variable is defined here, its type is str, but got [str]
+  |


### PR DESCRIPTION
## Summary

Fixes #1725 - Type checking for lambda forward references was order-dependent, even though runtime evaluation is order-independent.

### Problem

When a lambda is called before its declaration in source order, the call site only sees `any` type, so argument type errors are not caught at compile time:

```kcl
items = { k: f(k, v) for k, v in _xs }  # No type error here!
f = lambda a: str, b: str -> str { a + "/" + b }
```

### Solution

Implement a pre-scan for top-level lambda declarations (mirroring the existing schema pre-scan):

1. **`init_global_lambda_types()`** - Scans top-level `AssignStmt`s with lambda RHS and records `FunctionType` signatures in `Context::global_lambda_tys`
2. **`walk_call_expr` enhancement** - When callee resolves to `any`, looks up the pre-scanned signature to validate arguments
3. **`parse_lambda_params()`** - Extracted helper shared by pre-scan and main walk

### Test Plan

- [x] Added `lambda_forward_reference.k` unit test
- [x] Added grammar test `lambda_forward_reference_type_check/`
- [x] Manual testing with issue #1725 reproduction case

🤖 Generated with [Claude Code](https://claude.com/claude-code)