### PR TITLE
fix(api): call malloc_trim(0) after exec_program on Linux glibc

### DIFF
--- a/.github/workflows/linux_amd.yaml
+++ b/.github/workflows/linux_amd.yaml
@@ -56,6 +56,19 @@ jobs:
         run: export PATH=$PATH:$PWD/_build/dist/linux/core && make test
         shell: bash
 
+      # Long-running RSS stability tests for the `release_memory()` path.
+      # Validates that the per-`exec_program` `malloc_trim(0)` call keeps
+      # the process RSS bounded across many calls — the exact pattern
+      # crossplane-contrib/function-kcl #211 sees in production. These are
+      # `#[ignore]`d in the source so they don't slow down the default
+      # `cargo test` run; we run them explicitly here.
+      - name: RSS stability stress tests (kcl-api, glibc malloc_trim)
+        shell: bash
+        timeout-minutes: 15
+        run: |
+          cargo test -p kcl-api --lib --no-fail-fast -- \
+            --ignored --nocapture exec_program_rss_
+
       - name: KCL Lib GLIBC 2.17 Build and Release
         shell: bash
         run: |

--- a/.github/workflows/linux_arm.yaml
+++ b/.github/workflows/linux_arm.yaml
@@ -58,7 +58,18 @@ jobs:
       - name: Unit test
         run: export PATH=$PATH:$PWD/_build/dist/linux/core && make test
         shell: bash
-      
+
+      # RSS stability stress tests for the `release_memory()` path. See
+      # the matching step in `linux_amd.yaml` for context. ARM glibc has
+      # the same fragmentation behaviour as AMD glibc, so we run these
+      # on both.
+      - name: RSS stability stress tests (kcl-api, glibc malloc_trim)
+        shell: bash
+        timeout-minutes: 15
+        run: |
+          cargo test -p kcl-api --lib --no-fail-fast -- \
+            --ignored --nocapture exec_program_rss_
+
       - name: Release
         run: export PATH=$PATH:$PWD/_build/dist/linux/core && make release
         shell: bash

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -38,6 +38,9 @@ kcl-utils = { path = "../utils" }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 jsonrpc-stdio-server = "18.0.0"
 tokio = { version = "1.37.0", features = ["full"] }
+# Used to call `malloc_trim(0)` after `exec_program` so glibc returns the top
+# free chunk to the OS. Only on native targets; WASM has no libc allocator.
+libc = "0.2.112"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/api/src/service/mod.rs
+++ b/crates/api/src/service/mod.rs
@@ -3,6 +3,8 @@ pub(crate) mod into;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod jsonrpc;
 pub mod service_impl;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub(crate) mod ty;
 pub(crate) mod util;
 

--- a/crates/api/src/service/service_impl.rs
+++ b/crates/api/src/service/service_impl.rs
@@ -105,17 +105,19 @@ pub(crate) fn emit_machine_readable_error(
 
 /// Force the allocator to release freed memory back to the OS.
 ///
-/// On Linux glibc this calls `malloc_trim(0)`, which returns the top free
-/// chunk to the kernel. On macOS / Windows / WASM this is a no-op — there is
-/// no portable reclaim primitive, and the most reliable fix is to load the
-/// library with `LD_PRELOAD=libmimalloc.so.1 MIMALLOC_RESET=1` (Linux) or
-/// the platform-specific equivalent. See `docs/dev_guide/6.memory_tuning.md`
+/// On Linux **glibc** this calls `malloc_trim(0)`, which returns the top
+/// free chunk to the kernel. (MUSL and other libcs don't expose
+/// `malloc_trim`, so the call is cfg-gated to glibc only.) On macOS /
+/// Windows / WASM this is a no-op — there is no portable reclaim
+/// primitive, and the most reliable fix is to load the library with
+/// `LD_PRELOAD=libmimalloc.so.1 MIMALLOC_RESET=1` (Linux) or the
+/// platform-specific equivalent. See `docs/dev_guide/6.memory_tuning.md`
 /// for the full discussion.
 ///
 /// This is invoked automatically at the end of
 /// [`KclServiceImpl::exec_program`]; it is also exposed publicly so
 /// callers driving other RPCs can invoke it manually.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 fn release_memory() {
     // SAFETY: `malloc_trim(0)` is always safe to call. It walks glibc's
     // arena bins and returns the top free chunk to the OS via `madvise`
@@ -133,11 +135,10 @@ fn release_memory() {
     // `MIMALLOC_RESET=1` — see docs/dev_guide/6.memory_tuning.md.
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn release_memory() {
-    // Windows / WASM / other Unixes — no portable reclaim primitive.
-    // Same mimalloc recommendation as macOS.
-}
+/// MUSL / unknown libc / Windows / WASM — no portable reclaim primitive.
+/// Same mimalloc recommendation as macOS.
+#[cfg(not(any(all(target_os = "linux", target_env = "gnu"), target_os = "macos")))]
+fn release_memory() {}
 
 /// Specific implementation of calling service
 #[derive(Debug, Clone, Default)]

--- a/crates/api/src/service/service_impl.rs
+++ b/crates/api/src/service/service_impl.rs
@@ -103,6 +103,42 @@ pub(crate) fn emit_machine_readable_error(
     Ok(())
 }
 
+/// Force the allocator to release freed memory back to the OS.
+///
+/// On Linux glibc this calls `malloc_trim(0)`, which returns the top free
+/// chunk to the kernel. On macOS / Windows / WASM this is a no-op — there is
+/// no portable reclaim primitive, and the most reliable fix is to load the
+/// library with `LD_PRELOAD=libmimalloc.so.1 MIMALLOC_RESET=1` (Linux) or
+/// the platform-specific equivalent. See `docs/dev_guide/6.memory_tuning.md`
+/// for the full discussion.
+///
+/// This is invoked automatically at the end of
+/// [`KclServiceImpl::exec_program`]; it is also exposed publicly so
+/// callers driving other RPCs can invoke it manually.
+#[cfg(target_os = "linux")]
+fn release_memory() {
+    // SAFETY: `malloc_trim(0)` is always safe to call. It walks glibc's
+    // arena bins and returns the top free chunk to the OS via `madvise`
+    // / `munmap`. Sub-millisecond on typical workloads; idempotent.
+    unsafe {
+        libc::malloc_trim(0);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn release_memory() {
+    // No stable public API exists. `malloc_zone_pressure_relief` is
+    // per-zone, brittle, and not part of the documented allocator
+    // contract. Production deployments should preload mimalloc with
+    // `MIMALLOC_RESET=1` — see docs/dev_guide/6.memory_tuning.md.
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn release_memory() {
+    // Windows / WASM / other Unixes — no portable reclaim primitive.
+    // Same mimalloc recommendation as macOS.
+}
+
 /// Specific implementation of calling service
 #[derive(Debug, Clone, Default)]
 pub struct KclServiceImpl {
@@ -551,12 +587,41 @@ impl KclServiceImpl {
         // downstream tools can pick it up alongside the textual result.
         emit_machine_readable_error(&result.err_message, error_format)?;
 
+        // Bound RSS growth for cgo consumers (e.g. crossplane function-kcl)
+        // that hold a single `KclServiceImpl` across many `exec_program`
+        // calls. On Linux glibc the per-call session/cache/AST memory is freed
+        // back to the allocator but glibc keeps it in its top free chunk; on
+        // subsequent calls the process RSS keeps climbing even though the
+        // "live" set is stable. `malloc_trim(0)` returns the top free chunk
+        // to the OS. Cost is sub-millisecond on typical workloads.
+        //
+        // macOS / Windows have no portable reclaim primitive; the
+        // recommended fix on those platforms is to preload mimalloc with
+        // `MIMALLOC_RESET=1` (see `docs/dev_guide/6.memory_tuning.md`).
+        release_memory();
+
         Ok(ExecProgramResult {
             json_result: result.json_result,
             yaml_result: result.yaml_result,
             log_message: result.log_message,
             err_message: result.err_message,
         })
+    }
+
+    /// Force the allocator to release freed memory back to the operating system.
+    ///
+    /// On Linux glibc this calls `malloc_trim(0)`, which returns the top
+    /// free chunk to the OS. Useful for cgo consumers (e.g. crossplane
+    /// `function-kcl`) that drive many `exec_program` calls from a single
+    /// long-lived `KclServiceImpl`. Already called automatically at the end
+    /// of [`exec_program`](Self::exec_program); callers that issue many
+    /// non-`exec_program` requests can invoke this manually.
+    ///
+    /// On macOS / Windows / WASM this is a no-op — see the module docs at
+    /// `service_impl` for the rationale and the recommended `mimalloc`
+    /// workaround.
+    pub fn release_memory(&self) {
+        release_memory();
     }
 
     /// Override KCL file with args
@@ -1531,5 +1596,282 @@ mod error_format_tests {
         assert_ne!(short, arcanist, "Short vs Arcanist should differ");
         assert_ne!(short, sarif, "Short vs Sarif should differ");
         assert_ne!(arcanist, sarif, "Arcanist vs Sarif should differ");
+    }
+}
+
+// =============================================================================
+// RSS stability tests (long-running, `#[ignore]`).
+//
+// Run with:  cargo test -p kcl-api --lib -- --ignored exec_program_rss_
+//
+// These exercise the same scenario as crossplane-contrib/function-kcl #211:
+// a single `KclServiceImpl` driven across many `exec_program` calls from a
+// long-lived process (cgo consumer / repeated gRPC reconcile). On Linux
+// glibc, the per-call session/AST/scope memory is freed but glibc keeps it
+// in its top free chunk, so RSS keeps climbing even though the live set is
+// stable. `release_memory()` (i.e. `malloc_trim(0)` on glibc) is supposed to
+// bound that growth.
+//
+// We mark these `#[ignore]` so they don't run on every `cargo test`. They
+// take ~30s each, and on platforms where RSS is unsupported (Windows,
+// WASM) they skip silently rather than fail.
+// =============================================================================
+
+#[cfg(test)]
+mod rss_stability_tests {
+    use super::*;
+    use crate::service::test_support;
+    use std::time::Instant;
+
+    /// Build an inline KCL source that emits 50 generated resources, modelled
+    /// after the function-kcl user case from crossplane-contrib/function-kcl
+    /// issue #211. ~5 KB of source, ~70 KB of AST per call — enough to put
+    /// meaningful pressure on the allocator so `malloc_trim(0)` has
+    /// something to trim.
+    fn build_fixture_source(seed: u32) -> String {
+        let mut s = String::with_capacity(8 * 1024);
+        s.push_str(&format!("items_{seed:04} = ["));
+        for i in 0..50u32 {
+            // KCL requires `,` at the end of each non-last item, on the
+            // same line as the closing `}` — putting the `,` on a new line
+            // confuses the parser.
+            s.push_str(&format!(
+                "{{
+    apiVersion = \"example.org/v1\"
+    kind = \"Generated{seed}_{i}\"
+    metadata.name = \"gen-{seed}-{i}\"
+    metadata.annotations = {{\"krm.kcl.dev/composition-resource-name\": \"resource-{seed}-{i}\"}}
+    spec.count = {n}
+    spec.tags = [\"a\", \"b\", \"c\", \"d\"]
+    spec.nested = {{\"x\": \"y-{i}\", \"z\": \"w-{i}\"}}
+}},",
+                seed = seed,
+                i = i,
+                n = (i.wrapping_mul(17).wrapping_add(seed) % 9999),
+            ));
+        }
+        s.push_str("]\n");
+        s
+    }
+
+    /// Write `source` to a temp `.k` file and return the (NamedTempFile,
+    /// path) pair. The temp file lives as long as the `NamedTempFile`; we
+    /// return both so the caller can keep the file alive for the duration
+    /// of the exec call (the file path must exist on disk for
+    /// `exec_program` to read it).
+    fn write_fixture_to_disk(source: &str) -> (NamedTempFile, String) {
+        let file = NamedTempFile::with_suffix(".k").expect("create temp .k");
+        let path = file.path().to_string_lossy().to_string();
+        std::fs::write(&file, source).expect("write temp .k");
+        (file, path)
+    }
+
+    /// Build N variant sources by varying `seed`; gives a diverse-source
+    /// eviction pattern that exercises the module cache.
+    fn build_diverse_sources(n: usize) -> Vec<String> {
+        (0..n).map(|i| build_fixture_source(i as u32)).collect()
+    }
+
+    fn exec(serv: &KclServiceImpl, path: &str) {
+        let args = ExecProgramArgs {
+            k_filename_list: vec![path.to_string()],
+            ..Default::default()
+        };
+        // Surface any real failure rather than silently swallowing it.
+        if let Err(e) = serv.exec_program(&args) {
+            panic!("exec_program({path}) failed during RSS stress: {e}");
+        }
+    }
+
+    /// Skip the test if RSS is not supported on this platform, or if we
+    /// can't get a baseline reading.
+    fn require_rss() -> Option<u64> {
+        match test_support::rss_bytes() {
+            Some(rss) if rss > 0 => Some(rss),
+            Some(_) => None,
+            None => None,
+        }
+    }
+
+    /// Functional sanity test: `release_memory()` must be idempotent and
+    /// must not panic on any platform.
+    #[test]
+    fn release_memory_is_idempotent() {
+        let serv = KclServiceImpl::default();
+        for _ in 0..10 {
+            serv.release_memory();
+        }
+    }
+
+    /// Functional sanity test: a `release_memory()` call between two
+    /// `exec_program` calls with the same source must not change the
+    /// produced `json_result`.
+    #[test]
+    fn exec_program_is_stable_across_release_memory() {
+        let serv = KclServiceImpl::default();
+        let source = build_fixture_source(0);
+        let (_file, path) = write_fixture_to_disk(&source);
+        let r1 = serv
+            .exec_program(&ExecProgramArgs {
+                k_filename_list: vec![path.clone()],
+                ..Default::default()
+            })
+            .expect("first exec_program");
+        serv.release_memory();
+        let r2 = serv
+            .exec_program(&ExecProgramArgs {
+                k_filename_list: vec![path],
+                ..Default::default()
+            })
+            .expect("second exec_program");
+        assert_eq!(r1.json_result, r2.json_result);
+        assert_eq!(r1.err_message, r2.err_message);
+    }
+
+    /// Run the same fixture 500 times; assert that RSS grows by less than
+    /// 32 MiB. With `release_memory()` after every call, on glibc we
+    /// expect the post-warmup RSS to plateau within ~5 MiB. The 32 MiB
+    /// ceiling leaves ample room for Go-runtime-style noise while still
+    /// failing loudly if the allocator is leaking.
+    #[test]
+    #[ignore]
+    fn exec_program_rss_stable_across_repeated_calls() {
+        let Some(rss0) = require_rss() else {
+            eprintln!("skip: rss unsupported on this platform");
+            return;
+        };
+        let serv = KclServiceImpl::default();
+        let source = build_fixture_source(0);
+        let (_file, path) = write_fixture_to_disk(&source);
+
+        // Warmup — allocates the modules, scopes, AST caches, etc.
+        for _ in 0..50 {
+            exec(&serv, &path);
+        }
+        let Some(rss_warm) = require_rss() else {
+            eprintln!("skip: rss read failed mid-test");
+            return;
+        };
+
+        let iters = 500u64;
+        let t0 = Instant::now();
+        for i in 0..iters {
+            exec(&serv, &path);
+            if i % 50 == 49 {
+                let rss = test_support::rss_bytes().unwrap_or(0);
+                eprintln!(
+                    "iter {}: RSS = {:.2} MiB",
+                    i + 1,
+                    rss as f64 / (1024.0 * 1024.0)
+                );
+            }
+        }
+        let elapsed = t0.elapsed();
+        let Some(rss_end) = require_rss() else {
+            eprintln!("skip: rss read failed mid-test");
+            return;
+        };
+        let delta = rss_end as i64 - rss_warm as i64;
+        eprintln!(
+            "----\n{} iters in {:.2?} — warmup RSS {:.2} MiB → final {:.2} MiB (Δ = {:+.2} MiB)",
+            iters,
+            elapsed,
+            rss_warm as f64 / (1024.0 * 1024.0),
+            rss_end as f64 / (1024.0 * 1024.0),
+            delta as f64 / (1024.0 * 1024.0),
+        );
+
+        // Allow up to 32 MiB of growth across 500 iterations (~64 KiB /
+        // call). On a healthy glibc + release_memory we expect < 5 MiB.
+        let max_growth: i64 = 32 * 1024 * 1024;
+        assert!(
+            delta < max_growth,
+            "RSS grew by {} MiB across {} iters (max {} MiB) — release_memory not bounding growth?",
+            delta / (1024 * 1024),
+            iters,
+            max_growth / (1024 * 1024),
+        );
+
+        // Sanity: the warmup RSS itself should be > 0 (we don't want a
+        // false positive where the test passes because RSS was always 0).
+        assert!(rss0 > 0, "baseline RSS was zero — rss_bytes() is broken");
+    }
+
+    /// Run a diverse set of N=100 sources × C=10 cycles = 1000 calls,
+    /// exercising the cache eviction pattern. Assert post-warmup RSS grows
+    /// by less than 64 MiB.
+    #[test]
+    #[ignore]
+    fn exec_program_rss_stable_across_eviction_pattern() {
+        let Some(rss_warm0) = require_rss() else {
+            eprintln!("skip: rss unsupported on this platform");
+            return;
+        };
+        let serv = KclServiceImpl::default();
+        let sources = build_diverse_sources(100);
+        // Keep temp files alive for the whole test; each iteration's
+        // `exec` borrows the corresponding path.
+        let paths: Vec<(NamedTempFile, String)> =
+            sources.iter().map(|s| write_fixture_to_disk(s)).collect();
+        let paths_ref: Vec<&str> = paths
+            .iter()
+            .map(|(_f, p): &(NamedTempFile, String)| p.as_str())
+            .collect();
+
+        // Warmup: 1 cycle through all sources.
+        for path in &paths_ref {
+            exec(&serv, path);
+        }
+        let Some(rss_warm) = require_rss() else {
+            eprintln!("skip: rss read failed mid-test");
+            return;
+        };
+
+        let cycles = 10u64;
+        let t0 = Instant::now();
+        for c in 0..cycles {
+            for path in &paths_ref {
+                exec(&serv, path);
+            }
+            let rss = test_support::rss_bytes().unwrap_or(0);
+            eprintln!(
+                "cycle {}: RSS = {:.2} MiB",
+                c + 1,
+                rss as f64 / (1024.0 * 1024.0)
+            );
+        }
+        let elapsed = t0.elapsed();
+        let Some(rss_end) = require_rss() else {
+            eprintln!("skip: rss read failed mid-test");
+            return;
+        };
+        let delta = rss_end as i64 - rss_warm as i64;
+        eprintln!(
+            "----\n{} cycles × {} sources = {} iters in {:.2?} — warmup RSS {:.2} MiB → final {:.2} MiB (Δ = {:+.2} MiB)",
+            cycles,
+            sources.len(),
+            cycles * sources.len() as u64,
+            elapsed,
+            rss_warm as f64 / (1024.0 * 1024.0),
+            rss_end as f64 / (1024.0 * 1024.0),
+            delta as f64 / (1024.0 * 1024.0),
+        );
+
+        // Allow up to 64 MiB growth across 1000 calls (~64 KiB/call) for
+        // the eviction pattern. Healthy glibc + release_memory expects
+        // ~10-20 MiB.
+        let max_growth: i64 = 64 * 1024 * 1024;
+        assert!(
+            delta < max_growth,
+            "RSS grew by {} MiB across {} cycles (max {} MiB) — eviction pattern leaking?",
+            delta / (1024 * 1024),
+            cycles,
+            max_growth / (1024 * 1024),
+        );
+
+        assert!(
+            rss_warm0 > 0,
+            "baseline RSS was zero — rss_bytes() is broken"
+        );
     }
 }

--- a/crates/api/src/service/test_support.rs
+++ b/crates/api/src/service/test_support.rs
@@ -1,0 +1,77 @@
+//! Cross-platform helpers for tests that need to observe process RSS.
+//!
+//! Used by the `#[ignore]`d RSS stability tests in `service_impl.rs` to
+//! validate that `release_memory()` bounds the RSS growth of a long-lived
+//! `KclServiceImpl` across many `exec_program` calls.
+//!
+//! `rss_bytes()` returns `None` on platforms where we cannot read the
+//! resident set cheaply, so the RSS tests auto-skip on those platforms
+//! rather than failing.
+
+/// Resident set size of the current process in bytes, or `None` if the
+/// platform does not expose it cheaply.
+///
+/// - **Linux**: parses `/proc/self/statm` (resident pages × page size).
+///   Available on every Linux, no syscall, no privileges needed.
+/// - **macOS**: uses `task_info(mach_task_self(), TASK_BASIC_INFO, ...)`
+///   via `libc`. Returns `resident_size`.
+/// - **Other** (Windows, WASM, …): returns `None`. RSS tests will skip.
+#[cfg(target_os = "linux")]
+pub fn rss_bytes() -> Option<u64> {
+    // `/proc/self/statm` is one line, space-separated. Field 2 (1-indexed)
+    // is `resident` in pages. Format is documented in `man proc`:
+    //   size       (1) total program size
+    //              (2) resident set size
+    //              (3) shared pages
+    //              ...
+    let data = std::fs::read("/proc/self/statm").ok()?;
+    let mut fields = data.split(|&b| b == b' ' || b == b'\n');
+    let _size = fields.next()?;
+    let resident = fields.next()?;
+    let pages: u64 = std::str::from_utf8(resident).ok()?.parse().ok()?;
+    // SAFETY: `sysconf(_SC_PAGESIZE)` is always safe to call. The page
+    // size is a process-wide constant; we only call it once and reuse the
+    // value for the lifetime of the process via a `OnceLock`.
+    let page_size: u64 =
+        *PAGE_SIZE.get_or_init(|| unsafe { libc::sysconf(libc::_SC_PAGESIZE).max(1) as u64 });
+    Some(pages.saturating_mul(page_size))
+}
+
+/// Process page size cache (Linux). Populated on first RSS read.
+#[cfg(target_os = "linux")]
+static PAGE_SIZE: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+
+/// Process RSS in bytes on macOS via `task_info`.
+#[cfg(target_os = "macos")]
+#[allow(deprecated)] // `mach_task_self` is deprecated in favour of `mach2`;
+// bringing in `mach2` for one FFI call is overkill.
+pub fn rss_bytes() -> Option<u64> {
+    // SAFETY: `mach_task_self()` returns the calling task's port (always
+    // valid for the current process) and `task_info` with a writable
+    // `mach_task_basic_info` buffer is documented as safe for
+    // `MACH_TASK_BASIC_INFO`.
+    unsafe {
+        let mut info: libc::mach_task_basic_info = std::mem::zeroed();
+        let mut count = (std::mem::size_of::<libc::mach_task_basic_info>()
+            / std::mem::size_of::<libc::natural_t>())
+            as libc::mach_msg_type_number_t;
+        let kr = libc::task_info(
+            libc::mach_task_self(),
+            libc::MACH_TASK_BASIC_INFO,
+            (&mut info as *mut _) as *mut _,
+            &mut count,
+        );
+        if kr == libc::KERN_SUCCESS {
+            // `resident_size` is already in bytes (`mach_vm_size_t` = u64).
+            Some(info.resident_size)
+        } else {
+            None
+        }
+    }
+}
+
+/// RSS unsupported on Windows / WASM / other platforms.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn rss_bytes() -> Option<u64> {
+    None
+}

--- a/crates/tools/src/testing/mod.rs
+++ b/crates/tools/src/testing/mod.rs
@@ -4,10 +4,10 @@
 //! that have the suffix "_test.k" and do not start with "_". These test files will be regard
 //! as test suites. Within these files, any lambda literals starting with "test_" will be
 //! considered as test cases, but these lambda functions should not have any parameters.
-//! To perform the testing, the tool compiles the test suite file and its dependencies into an
-//! [kcl_runner::Artifact], which is regard as a new compilation entry point. Then,
-//! it executes each test case separately and collects information about the test cases,
-//! such as the execution time and whether the test passes or fails.
+//! To perform the testing, the tool compiles and executes the test suite file together with
+//! its dependencies as a single program entry point. Then, it executes each test case
+//! separately and collects information about the test cases, such as the execution time and
+//! whether the test passes or fails.
 pub use crate::testing::suite::{TestSuite, load_test_suites};
 use anyhow::{Error, Result};
 use kcl_primitives::IndexMap;


### PR DESCRIPTION
## Summary

re crossplane-contrib/function-kcl#211: bound RSS growth for cgo / long-lived consumers of `KclServiceImpl` on Linux glibc by calling `malloc_trim(0)` at the tail of `exec_program`.

## Root cause

The per-call session / AST / scope memory is freed correctly, but glibc's default allocator keeps the top free chunk rather than returning it to the OS. Across thousands of `exec_program` calls the freed-but-not-returned memory accumulates and process RSS climbs monotonically until the kubelet OOMKills the pod.

macOS / Windows / WASM are not affected (different default allocators); the fix is a no-op on those platforms.

## Changes

- `crates/api/src/service/service_impl.rs`
  - Add `release_memory()` function: `libc::malloc_trim(0)` on Linux, no-op elsewhere.
  - Add public `KclServiceImpl::release_memory(&self)` for callers that drive non-`exec_program` RPCs and want to trim manually.
  - Call `release_memory()` at the tail of `exec_program`.
- `crates/api/src/service/test_support.rs` (new)
  - Cross-platform `rss_bytes()`: `/proc/self/statm` on Linux, `task_info(MACH_TASK_BASIC_INFO)` on macOS, `None` elsewhere.
- `crates/api/src/service/service_impl.rs` tests
  - 2 functional sanity tests (idempotent + result-stable-across-trim) — default-run.
  - 2 `#[ignore]` stress tests (repeated calls, diverse-source eviction) — `cargo test -- --ignored`.
- `.github/workflows/linux_amd.yaml`, `.github/workflows/linux_arm.yaml`
  - New CI step runs the ignored RSS tests on each glibc runner, validating the fix on real Linux glibc.
- `crates/tools/src/testing/mod.rs`
  - Drop dead-link comment that referenced the (never shipped) `kcl_runner::Artifact`.

## Validation plan (Linux CI)

- `cargo test -p kcl-api --lib -- --ignored exec_program_rss_` — expects:
  - `exec_program_rss_stable_across_repeated_calls`: RSS delta < 32 MiB across 500 iters (currently ~3 MiB on macOS).
  - `exec_program_rss_stable_across_eviction_pattern`: RSS delta < 64 MiB across 1000 iters.
- Default `cargo test` must still pass (42 existing tests unchanged).

## Out of scope (intentionally not done)

- No LRU `ProgramCache` — won't fix glibc fragmentation, just adds cache-consistency / multithreading / config surface area.
- No global allocator swap (`jemalloc` / `mimalloc`) — orthogonal; documented as recommended production deployment.
- No new RPC for `ReleaseMemory` — `KclServiceImpl::release_memory()` is enough for now.