### PR TITLE
fix(evaluator): avoid double evaluation of forward-referenced top-level fields (fixes #1759)

### DIFF
--- a/crates/evaluator/src/lazy.rs
+++ b/crates/evaluator/src/lazy.rs
@@ -385,6 +385,29 @@ impl<'ctx> Evaluator<'ctx> {
         }
     }
 
+    /// If `key` was already resolved earlier through backtracking (for example
+    /// forced by a forward reference) and it has a single setter, return its
+    /// cached value. This lets the top-level eager walk reuse the value instead
+    /// of evaluating the right-hand side a second time (see issue #1759).
+    ///
+    /// The single-setter guard keeps conditional or in-place reassignments
+    /// (`if` overrides, `+=`, subscript stores, ...) on the normal evaluation
+    /// path, where every setter must still run in order.
+    #[inline]
+    pub(crate) fn get_resolved_single_setter_value(
+        &self,
+        pkgpath: &str,
+        key: &str,
+    ) -> Option<ValueRef> {
+        let lazy_scopes = self.lazy_scopes.borrow();
+        let scope = lazy_scopes.get(pkgpath)?;
+        if scope.resolved.contains(key) && scope.setter_len(key) == 1 {
+            scope.cache.get(key).cloned()
+        } else {
+            None
+        }
+    }
+
     /// Set value to the context.
     #[inline]
     pub(crate) fn set_value_to_lazy_scope(&self, pkgpath: &str, key: &str, value: &ValueRef) {

--- a/crates/evaluator/src/node.rs
+++ b/crates/evaluator/src/node.rs
@@ -124,6 +124,28 @@ impl<'ctx> TypedResultWalker<'ctx> for Evaluator<'ctx> {
     }
 
     fn walk_assign_stmt(&self, assign_stmt: &'ctx ast::AssignStmt) -> Self::Result {
+        // Reuse the value of a top-level field that was already resolved early
+        // by a forward reference, instead of evaluating its right-hand side a
+        // second time during the eager walk (see issue #1759). This is limited
+        // to a single plain-name target at the global scope while not executing
+        // a setter, so conditional/in-place reassignments keep their normal
+        // ordered evaluation.
+        if assign_stmt.targets.len() == 1
+            && assign_stmt.targets[0].node.paths.is_empty()
+            && self.scope_level() == GLOBAL_LEVEL
+            && self.backtrack_meta.borrow().is_empty()
+        {
+            let name = assign_stmt.targets[0].node.name.node.as_str();
+            let pkgpath = self.current_pkgpath();
+            if let Some(cached) = self.get_resolved_single_setter_value(&pkgpath, name) {
+                // The value is already computed and cached; make sure the global
+                // variable holds it (the early backtracking may have produced the
+                // value without leaving it in the global scope) and skip the
+                // redundant right-hand side evaluation.
+                self.add_or_update_global_variable(name, cached.clone(), false);
+                return Ok(cached);
+            }
+        }
         self.clear_local_vars();
         // Set target vars.
         for name in &assign_stmt.targets {

--- a/crates/evaluator/src/tests.rs
+++ b/crates/evaluator/src/tests.rs
@@ -1558,3 +1558,57 @@ c = C()
         yaml_output
     );
 }
+
+#[test]
+fn assign_no_double_eval_on_forward_reference() {
+    // Regression test for issue #1759: a top-level field whose value is forced
+    // early by a forward reference must not be evaluated a second time during
+    // the eager walk. The `print` side effect makes the extra evaluation
+    // observable: `_foo` is referenced before its declaration (forward), while
+    // `_bar` is referenced after. Each `show(...)` must run exactly once.
+    let p = load_packages(&LoadPackageOptions {
+        paths: vec!["test.k".to_string()],
+        load_opts: Some(LoadProgramOptions {
+            k_code_list: vec![
+                r#"show = lambda s: str -> str {
+    print("show: ${s}")
+    s
+}
+
+# `_foo` used before declaration (forward reference)
+foo = _foo
+
+_foo = {
+    name: "foo"
+    value: show("foo")
+}
+
+_bar = {
+    name: "bar"
+    value: show("bar")
+}
+
+# `_bar` used after declaration
+bar = _bar
+"#
+                .to_string(),
+            ],
+            ..Default::default()
+        }),
+        load_builtin: false,
+        ..Default::default()
+    })
+    .unwrap();
+    let evaluator = Evaluator::new(&p.program);
+    evaluator
+        .run()
+        .expect("forward-reference program must evaluate successfully");
+    // Before the fix the log was "show: foo\nshow: foo\nshow: bar\n" because the
+    // forward reference forced `_foo` once and the eager walk evaluated it again.
+    let log = evaluator.runtime_ctx.borrow().log_message.clone();
+    assert_eq!(
+        log, "show: foo\nshow: bar\n",
+        "each field value must be evaluated exactly once; got log:\n{}",
+        log
+    );
+}

--- a/tests/grammar/assign/forward_reference_single_eval/main.k
+++ b/tests/grammar/assign/forward_reference_single_eval/main.k
@@ -1,0 +1,23 @@
+# Regression test for issue #1759: a top-level field forced early by a forward
+# reference must be evaluated exactly once. Each `show(...)` prints a unique
+# key line; a second evaluation would emit a duplicate key and change the
+# output. `_foo` is used before its declaration (forward reference) and `_bar`
+# after it.
+show = lambda s: str -> str {
+    print("eval_${s}: seen")
+    s
+}
+
+foo = _foo
+
+_foo = {
+    name = "foo"
+    value = show("foo")
+}
+
+_bar = {
+    name = "bar"
+    value = show("bar")
+}
+
+bar = _bar

--- a/tests/grammar/assign/forward_reference_single_eval/stdout.golden
+++ b/tests/grammar/assign/forward_reference_single_eval/stdout.golden
@@ -1,0 +1,8 @@
+eval_foo: seen
+eval_bar: seen
+foo:
+  name: foo
+  value: foo
+bar:
+  name: bar
+  value: bar

--- a/tests/grammar/schema/instances/simple/simple_10/stdout.golden
+++ b/tests/grammar/schema/instances/simple/simple_10/stdout.golden
@@ -1,2 +1,2 @@
 s: 'result: Xrd'
-instances: 2
+instances: 1

--- a/tests/grammar/schema/instances/simple/simple_8/stdout.golden
+++ b/tests/grammar/schema/instances/simple/simple_8/stdout.golden
@@ -4,4 +4,4 @@ my_resource:
   kind: ConfigMap
   metadata:
     name: test-resource
-instances_count: 2
+instances_count: 1


### PR DESCRIPTION
## What this PR does

Fixes #1759.

A top-level field that is **used before its declaration** (a forward reference) was evaluated **twice**:

1. once eagerly via lazy-scope backtracking, when the forward reference forced its value, and
2. again when the ordered walk reached the field's own assignment statement.

Besides the wasted work, the second evaluation re-ran the right-hand side **and its side effects**:

- for a plain value it duplicated `print` output (the exact symptom in #1759), and
- for a **schema instance** it registered a phantom second entry in `Schema.instances()` — the residual case that #2036 could not fully close.

### Reproduce (before this PR)

```kcl
show = lambda s: str -> str {
    print("show: ${s}")
    s
}
foo = _foo          # forward reference
_foo = { name = "foo", value = show("foo") }
_bar = { name = "bar", value = show("bar") }
bar = _bar
```

```
show: foo
show: foo   # <-- evaluated twice
show: bar
```

After this PR each `show: ...` line is printed exactly once.

## How

`walk_assign_stmt` now reuses the already-resolved value for a **single plain-name target at the global scope** when it was resolved early via backtracking and has **exactly one setter** — it stores the cached value into the global variable and skips the redundant right-hand side evaluation.

The single-setter guard keeps conditional (`if`) overrides and in-place reassignments (`+=`, subscript stores) on the normal ordered-evaluation path, so their per-setter semantics are unchanged.

## Tests

- **Unit** (`crates/evaluator/src/tests.rs`): `assign_no_double_eval_on_forward_reference` asserts, via the `print` log, that each field value is evaluated exactly once.
- **Grammar E2E** (`tests/grammar/assign/forward_reference_single_eval`): new golden case.
- **Corrected goldens**: `schema/instances/simple/simple_8` and `simple_10` updated from `2` to `1` instance, matching their own documented intent (`# Should return 1 instance`). These were recorded against the pre-fix double-evaluation.

## Verification

- `cargo test -p kcl-evaluator` — 114 passed
- Full grammar suite (`tests/grammar`) — 1592 passed
- `cargo fmt -p kcl-evaluator --check` clean; no new clippy warnings