### PR TITLE
fix(resolver): type-check config literals in list/dict schema attribute defaults (fixes #1737)

### DIFF
--- a/crates/sema/src/resolver/node.rs
+++ b/crates/sema/src/resolver/node.rs
@@ -420,16 +420,34 @@ impl<'ctx> MutSelfTypedResultWalker<'ctx> for Resolver<'_> {
             },
         );
         if let Some(value) = &schema_attr.value {
-            let value_ty = if let TypeKind::Schema(ty) = &expected_ty.kind {
-                let (start, end) = value.get_span_pos();
-                let obj =
-                    self.new_config_expr_context_item(&ty.name, expected_ty.clone(), start, end);
-                let init_stack_depth = self.switch_config_expr_context(Some(obj));
-                let value_ty = self.expr(value);
-                self.clear_config_expr_context(init_stack_depth as usize, false);
-                value_ty
-            } else {
-                self.expr(value)
+            let value_ty = match &expected_ty.kind {
+                TypeKind::Schema(ty) => {
+                    let (start, end) = value.get_span_pos();
+                    let obj = self.new_config_expr_context_item(
+                        &ty.name,
+                        expected_ty.clone(),
+                        start,
+                        end,
+                    );
+                    let init_stack_depth = self.switch_config_expr_context(Some(obj));
+                    let value_ty = self.expr(value);
+                    self.clear_config_expr_context(init_stack_depth as usize, false);
+                    value_ty
+                }
+                // Propagate the expected container type into the default value so
+                // config literals nested in a list/dict/union attribute default are
+                // still checked against their schema element type at compile time
+                // (see issue #1737), matching `upgrade_type_for_expr`.
+                TypeKind::List(_) | TypeKind::Dict(_) | TypeKind::Union(_) => {
+                    let (start, end) = value.get_span_pos();
+                    let obj =
+                        self.new_config_expr_context_item("[]", expected_ty.clone(), start, end);
+                    let init_stack_depth = self.switch_config_expr_context(Some(obj));
+                    let value_ty = self.expr(value);
+                    self.clear_config_expr_context(init_stack_depth as usize, false);
+                    value_ty
+                }
+                _ => self.expr(value),
             };
             match &schema_attr.op {
                 // Union operator

--- a/crates/sema/src/resolver/test_fail_data/unmatched_schema_attr_list_default.k
+++ b/crates/sema/src/resolver/test_fail_data/unmatched_schema_attr_list_default.k
@@ -1,0 +1,8 @@
+# Issue #1737: a config literal nested in a list-typed schema attribute default
+# value must be type-checked against its element schema at compile time. Here
+# `name_typo` is not an attribute of `Item`, so a compile error is expected.
+schema Config:
+    conditions?: [Item] = [{name_typo: "kcl"}]
+
+schema Item:
+    name: str

--- a/crates/sema/src/resolver/tests.rs
+++ b/crates/sema/src/resolver/tests.rs
@@ -188,6 +188,7 @@ fn test_resolve_program_fail() {
         "unmatched_schema_attr_1.k",
         "unmatched_schema_attr_2.k",
         "unmatched_schema_attr_3.k",
+        "unmatched_schema_attr_list_default.k",
     ];
     for case in cases {
         let path = Path::new(work_dir).join(case);


### PR DESCRIPTION
## What this PR does

Fixes #1737.

A schema attribute default whose declared type is a **container of schemas** was not type-checked at compile time:

```kcl
schema Config:
    conditions?: [Item] = [{name_typo: "kcl"}]   # `name_typo` is not an Item attribute

schema Item:
    name: str

c = Config {}
```

Before this PR the mistake surfaced only as a **runtime** `EvaluationError` (`expect [Item], got list`). After this PR it is reported at **compile time**, pointing right at the bad key:

```
error[E2L23]: CompileError
 --> conditions?: [Item] = [{name_typo: "kcl"}]
                             ^ Cannot add member 'name_typo' to schema 'Item', did you mean '["name"]'?
```

## Root cause

`walk_schema_attr` set up the config-expression context (which drives the config-to-schema attribute check in `config.rs`) **only** when the attribute's expected type was a `Schema`; for `List`/`Dict`/`Union` it walked the default value with no context, so nested config literals were never checked against their element schema.

The top-level assignment path (`walk_assign_stmt`) already handles `Schema` **and** `List | Dict | Union` with the same pattern (that is why `x: [Item] = [{name_typo: ...}]` at the top level already errored). This change brings `walk_schema_attr` in line with it, mirroring `upgrade_type_for_expr`.

As a side benefit, dict-of-schema defaults (`{str: Item} = {a = {name_typo: ...}}`) are now caught at compile time too.

## Not changed

Plain container defaults (`[str]`, `[int]`, `[]`), valid schema-element defaults (`[{name: "kcl"}]`), and valid union defaults keep working — verified below. The harder `int | [Item]` union-of-list case is out of scope and still behaves as before (no regression).

## Tests

- New resolver fail-case `crates/sema/src/resolver/test_fail_data/unmatched_schema_attr_list_default.k`, registered in `test_resolve_program_fail`.

## Verification

- `cargo test -p kcl-sema` — 59 passed
- Full grammar suite (`tests/grammar`) — 1591 passed (no regressions)
- `cargo fmt -p kcl-sema --check` clean; no new clippy warnings