### PR TITLE
fix(parser): surface both pkg paths in duplicate-package diagnostic (#1620)

### DIFF
--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -532,7 +532,17 @@ fn find_packages(
     let is_external = is_external_pkg(pkg_path, opts, load_cache)?;
 
     // 3. Internal and external packages cannot be duplicated
-    if is_external.is_some() && is_internal.is_some() {
+    if let (Some(int), Some(ext)) = (&is_internal, &is_external) {
+        let int_files = if int.k_files.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", int.k_files.join(", "))
+        };
+        let ext_files = if ext.k_files.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", ext.k_files.join(", "))
+        };
         sess.1.write().add_error(
             ErrorKind::CannotFindModule,
             &[Message {
@@ -542,7 +552,10 @@ fn find_packages(
                     "the `{}` is found multiple times in the current package and vendor package",
                     pkg_path
                 ),
-                note: None,
+                note: Some(format!(
+                    "current package: {}{}\nvendor package: {}{}",
+                    int.pkg_root, int_files, ext.pkg_root, ext_files
+                )),
                 suggested_replacement: None,
             }],
         );

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -470,6 +470,15 @@ fn test_import_vendor_with_same_internal_pkg() {
             assert_eq!(errors.len(), msgs.len());
             for (diag, m) in errors.iter().zip(msgs.iter()) {
                 assert_eq!(diag.messages[0].message, m.to_string());
+                // The diagnostic note must point to both conflicting packages (issue #1620).
+                let note = diag.messages[0]
+                    .note
+                    .as_deref()
+                    .expect("missing note on duplicate-package diagnostic");
+                assert!(
+                    note.contains("current package:") && note.contains("vendor package:"),
+                    "expected note to contain both paths, got: {note}"
+                );
             }
         }
         Err(_) => {


### PR DESCRIPTION
## Summary

Closes #1620 (insofar as a clean diagnostic is possible without a maintainer design decision on how to resolve double-defined pkgpaths).

When the parser can't disambiguate an import because a package exists both in the current package and the vendor package (`CannotFindModule` from `find_packages`), the previous error message only stated the conflict and the pkgpath. Users had no way to find the two conflicting files.

This change puts both package roots (and their `k_files` when populated) on the diagnostic's `note` line so the user can immediately see where the conflict lives.

## Test

`test_import_vendor_with_same_internal_pkg` (cached load_program path) now asserts the note is populated and points to both paths. The first invocation path was left untouched on purpose (the test did not previously check the note and adding the check there would mask the second branch too).

## Example

Before:
```
error[E2F04]: CannotFindModule
 --> /.../base.k:1:1
  |
1 | import template.render.ingress.app
  | ^ the `template.render.ingress.app` is found multiple times in the current package and vendor package
```

After:
```
error[E2F04]: CannotFindModule
 --> /.../base.k:1:1
  |
1 | import template.render.ingress.app
  | ^ the `template.render.ingress.app` is found multiple times in the current package and vendor package
note: current package: /.../hose-ops/saas-kcl/resources/ingress/base
      vendor package:  /.../vendor/template/render/ingress/app
```