### PR TITLE
fix(lsp): recover from missing schema_ty + drop wrong .k-file import completions (fixes #1736)

### DIFF
--- a/crates/sema/src/advanced_resolver/mod.rs
+++ b/crates/sema/src/advanced_resolver/mod.rs
@@ -1578,4 +1578,39 @@ mod tests {
         let node_ty_map = resolver::resolve_program(&mut program).node_ty_map;
         AdvancedResolver::resolve_program(&program, &mut gs, node_ty_map).unwrap();
     }
+
+    /// Regression test for issue #1736: when the legacy resolver fails to record a
+    /// type for a schema in `node_ty_map` (e.g., due to incremental cache
+    /// invalidation or a partial resolution failure), the advanced resolver used to
+    /// abort the entire program with `schema_ty not found`, taking down the LSP
+    /// until the user restarted it. The advanced resolver must instead skip
+    /// semantic enrichment for the affected schema and let the rest of the program
+    /// resolve normally.
+    #[test]
+    fn test_missing_schema_ty_does_not_abort_resolve_program() {
+        let sess = Arc::new(ParseSession::default());
+
+        let path = "src/advanced_resolver/test_data/schema_def_scope.k"
+            .to_string()
+            .replace("/", std::path::MAIN_SEPARATOR_STR);
+        let mut program = load_program(sess.clone(), &[&path], None, None)
+            .unwrap()
+            .program;
+        let mut gs = GlobalState::default();
+        Namer::find_symbols(&program, &mut gs);
+        let node_ty_map = resolver::resolve_program(&mut program).node_ty_map;
+
+        // Simulate the cache state that triggered the original bug: drop every
+        // entry from `node_ty_map` so neither `walk_schema_stmt` nor
+        // `walk_schema_expr` can find a type for any schema in the program.
+        {
+            let mut map = node_ty_map.borrow_mut();
+            map.clear();
+        }
+
+        // Before the fix this call propagated an `anyhow!` error from
+        // `walk_schema_stmt` and the LSP marked the workspace as `Failed`. With the
+        // fix the advanced resolver degrades gracefully and returns Ok.
+        AdvancedResolver::resolve_program(&program, &mut gs, node_ty_map).unwrap();
+    }
 }

--- a/crates/sema/src/advanced_resolver/node.rs
+++ b/crates/sema/src/advanced_resolver/node.rs
@@ -228,16 +228,21 @@ impl<'ctx> MutSelfTypedResultWalker<'ctx> for AdvancedResolver<'_> {
 
     fn walk_schema_stmt(&mut self, schema_stmt: &'ctx ast::SchemaStmt) -> Self::Result {
         let (start, end) = (self.ctx.start_pos.clone(), self.ctx.end_pos.clone());
-        let schema_ty = self
+        // The legacy resolver populates node_ty_map for every schema name it processes,
+        // but in rare cases (incremental invalidation, cyclic imports, or partially-failed
+        // resolution) the entry may be missing. Treat that as a degraded resolution for
+        // this schema and skip semantic enrichment rather than aborting the entire
+        // program — the LSP must keep working even when a single schema cannot be
+        // resolved.
+        let Some(schema_ty) = self
             .ctx
             .node_ty_map
             .borrow()
             .get(&self.ctx.get_node_key(&schema_stmt.name.id)?)
-            .ok_or(anyhow!(
-                "schema_ty not found when walk schema stmt {:?}",
-                schema_stmt
-            ))?
-            .clone();
+            .cloned()
+        else {
+            return Ok(None);
+        };
         let schema_symbol = self
             .gs
             .get_symbols()
@@ -883,16 +888,18 @@ impl<'ctx> MutSelfTypedResultWalker<'ctx> for AdvancedResolver<'_> {
 
     fn walk_schema_expr(&mut self, schema_expr: &'ctx ast::SchemaExpr) -> Self::Result {
         self.walk_identifier_expr(&schema_expr.name)?;
-        let schema_ty = self
+        // See `walk_schema_stmt` — if the legacy resolver did not record a type for
+        // this schema reference, skip semantic resolution for this expression rather
+        // than aborting.
+        let Some(schema_ty) = self
             .ctx
             .node_ty_map
             .borrow()
             .get(&self.ctx.get_node_key(&schema_expr.name.id)?)
-            .ok_or(anyhow!(
-                "schema_ty not found when walk schema expr {:?}",
-                schema_expr
-            ))?
-            .clone();
+            .cloned()
+        else {
+            return Ok(None);
+        };
         match schema_ty.kind {
             TypeKind::Schema(_) => {
                 self.expr(&schema_expr.config)?;

--- a/crates/tools/src/LSP/src/completion.rs
+++ b/crates/tools/src/LSP/src/completion.rs
@@ -480,56 +480,38 @@ fn completion_import_builtin_pkg() -> IndexSet<KCLCompletionItem> {
 
 fn completion_import_internal_pkg(
     program: &Program,
-    line_start_pos: &KCLPos,
+    _line_start_pos: &KCLPos,
 ) -> IndexSet<KCLCompletionItem> {
     let mut completions: IndexSet<KCLCompletionItem> = Default::default();
     if let Ok(entries) = fs::read_dir(program.root.clone()) {
         for entry in entries {
+            // KCL `import` statements always target a *package* (a directory),
+            // never a single `.k` file. A sibling file like `main.k` is therefore
+            // never a valid completion for `import …`, and previously slipped in
+            // here as a wrong completion suggestion (see kcl-lang/kcl#1736).
+            // Only suggest directories that contain at least one `.k` file — those
+            // are the sub-packages the user can actually `import`.
             if let Ok(entry) = entry
                 && let Ok(file_type) = entry.file_type()
+                && file_type.is_dir()
             {
-                // internal pkgs
-                if file_type.is_dir() {
-                    if let Ok(files) = get_kcl_files(entry.path(), true) {
-                        // skip folder if without kcl file
-                        if files.is_empty() {
-                            continue;
-                        }
-                    } else {
+                if let Ok(files) = get_kcl_files(entry.path(), true) {
+                    // skip folder if without kcl file
+                    if files.is_empty() {
                         continue;
-                    }
-                    if let Some(name) = entry.file_name().to_str() {
-                        completions.insert(KCLCompletionItem {
-                            label: name.to_string(),
-                            detail: None,
-                            documentation: None,
-                            kind: Some(KCLCompletionItemKind::Dir),
-                            insert_text: None,
-                            additional_text_edits: None,
-                        });
                     }
                 } else {
-                    // internal module
-                    let path = entry.path();
-                    if path.to_str().unwrap_or("").adjust_canonicalization()
-                        == line_start_pos.filename.adjust_canonicalization()
-                    {
-                        continue;
-                    }
-                    if let Some(extension) = path.extension()
-                        && extension == KCL_FILE_EXTENSION
-                        && let Some(name) = path.file_stem()
-                        && let Some(name) = name.to_str()
-                    {
-                        completions.insert(KCLCompletionItem {
-                            label: name.to_string(),
-                            detail: None,
-                            documentation: None,
-                            kind: Some(KCLCompletionItemKind::Module),
-                            insert_text: None,
-                            additional_text_edits: None,
-                        });
-                    }
+                    continue;
+                }
+                if let Some(name) = entry.file_name().to_str() {
+                    completions.insert(KCLCompletionItem {
+                        label: name.to_string(),
+                        detail: None,
+                        documentation: None,
+                        kind: Some(KCLCompletionItemKind::Dir),
+                        insert_text: None,
+                        additional_text_edits: None,
+                    });
                 }
             }
         }

--- a/crates/tools/src/LSP/src/snapshots/kcl_language_server__completion__tests__import_internal_pkg_test.snap
+++ b/crates/tools/src/LSP/src/snapshots/kcl_language_server__completion__tests__import_internal_pkg_test.snap
@@ -2,4 +2,4 @@
 source: tools/src/LSP/src/completion.rs
 expression: "format!(\"{:?}\", got_labels)"
 ---
-["foo", "tt"]
+["tt"]


### PR DESCRIPTION
## Summary

Closes kcl-lang/kcl#1736. The issue has two independent symptoms that both surface when working in a multi-package directory like `kcl-lang/konfig`:

1. The LSP wrongly suggests `main` (and any other sibling `.k` file's stem) as an `import` completion.
2. The LSP occasionally panics with `Resolve failed: schema_ty not found when walk schema stmt …` and never recovers until the user restarts VS Code.

This PR fixes both.

## Fix 1 — wrong `main` import completion

`completion_import_internal_pkg` in `crates/tools/src/LSP/src/completion.rs` iterated every entry of `program.root` and offered each `.k` file's stem as a `KCLCompletionItemKind::Module`. KCL `import` statements always target a *package* (a directory with or without `kcl.mod`), never a single `.k` file — sibling files are simply not valid import targets. Drop the .k-file branch and keep only the directory branch (which already filters empty directories).

The existing `import_internal_pkg_test` snapshot is updated to reflect that `foo` (a sibling .k file) is no longer offered; `tt` (a real sub-package) still is.

## Fix 2 — LSP non-recovery from `schema_ty not found`

In rare incremental scenarios (scope-cache invalidation, partial resolution failures, cyclic imports) the legacy resolver can leave `node_ty_map` without an entry for a schema name even though the advanced resolver later walks that schema via `walk_schema_stmt` or `walk_schema_expr`. Both walkers used to surface the missing entry with `.ok_or(anyhow!(...))?`, the error bubbled all the way up through `compile()` as `Resolve failed: schema_ty not found`, the workspace was marked `Failed`, and the user had to reload VS Code to recover.

Treat the missing entry as a degraded result: skip semantic enrichment for that schema and return `Ok(None)` instead of propagating the error. The LSP keeps responding to requests after the next keystroke instead of being pinned in a broken state.

## Test plan

- [x] New unit test `advanced_resolver::tests::test_missing_schema_ty_does_not_abort_resolve_program` runs the advanced resolver with an empty `node_ty_map` against `test_data/schema_def_scope.k`. Without fix #2 it reproduces the exact `schema_ty not found when walk schema stmt …` error from the issue; with the fix it passes cleanly.
- [x] Updated snapshot `kcl_language_server__completion__tests__import_internal_pkg_test.snap` covers fix #1: the only remaining suggestion is `tt` (a real sub-package), `foo` (a sibling .k file) is gone.
- [x] `cargo test -p kcl-sema` — 60 passed, 0 failed.
- [x] `cargo test -p kcl-language-server --lib` — 175 passed; the only 2 failing tests (`complete_unimport_schemas`, `pkg_mod_test`) were already failing on `main` before these changes.
- [x] `cargo build -p kcl-tools` succeeds.

The new regression test is purely additive — it simulates the cache state that produced the original bug, without depending on any private LSP state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)