### PR TITLE
fix(evaluator): let config entries shadow enclosing schema attrs (fixes #1769)

### DIFF
--- a/crates/evaluator/src/context.rs
+++ b/crates/evaluator/src/context.rs
@@ -171,6 +171,58 @@ impl<'ctx> Evaluator<'ctx> {
         self.loop_vars.borrow().contains(name)
     }
 
+    /// Enter a config expression scope for config entry variable marks.
+    #[inline]
+    pub(crate) fn enter_config_entry_scope(&self) {
+        self.config_entry_vars.borrow_mut().push(vec![]);
+    }
+
+    /// Mark a config entry name as a local variable, so that the following
+    /// sibling entries resolve it lexically in the current config scope
+    /// instead of falling back to an enclosing schema attribute of the same
+    /// name. Names that are already local (loop variables, lambda arguments,
+    /// entries of an outer config, ...) are left untouched so that leaving
+    /// this config scope does not drop a mark it does not own.
+    #[inline]
+    pub(crate) fn mark_config_entry_var(&self, name: &str) {
+        if self.is_local_var(name) {
+            return;
+        }
+        match self.config_entry_vars.borrow_mut().last_mut() {
+            Some(frame) => frame.push(name.to_string()),
+            // No enclosing config scope to undo the mark, so do not add one.
+            None => return,
+        }
+        self.add_local_var(name);
+    }
+
+    /// Leave a config expression scope and undo the marks it added.
+    #[inline]
+    pub(crate) fn leave_config_entry_scope(&self) {
+        let frame = self.config_entry_vars.borrow_mut().pop();
+        if let Some(frame) = frame {
+            for name in frame {
+                self.remove_local_var(&name);
+            }
+        }
+    }
+
+    /// Re-assert the marks of the current config scope.
+    ///
+    /// Evaluating a nested schema body runs `clear_local_vars` for every schema
+    /// attribute, which drops the marks of the config expression we are still
+    /// walking. Re-asserting them before each entry keeps the preceding sibling
+    /// entries visible to the following ones.
+    #[inline]
+    pub(crate) fn restore_config_entry_vars(&self) {
+        if let Some(frame) = self.config_entry_vars.borrow().last() {
+            let mut local_vars = self.local_vars.borrow_mut();
+            for name in frame {
+                local_vars.insert(name.clone());
+            }
+        }
+    }
+
     #[inline]
     pub(crate) fn clear_local_vars(&self) {
         self.local_vars.borrow_mut().clear();

--- a/crates/evaluator/src/lib.rs
+++ b/crates/evaluator/src/lib.rs
@@ -93,6 +93,10 @@ pub struct Evaluator<'ctx> {
     pub lazy_reassign: RefCell<bool>,
     /// Loop (comprehension/quantifier) target variables, a subset of local_vars.
     pub loop_vars: RefCell<HashSet<String>>,
+    /// Names newly marked as local variables by config entries, one frame per
+    /// config expression scope. Used to undo the marks when the config
+    /// expression is left, so the shadowing does not outlive its scope.
+    pub config_entry_vars: RefCell<Vec<Vec<String>>>,
     /// Schema attr backtrack meta.
     pub backtrack_meta: RefCell<Vec<BacktrackMeta>>,
     /// Current AST id for the evaluator walker.
@@ -161,6 +165,7 @@ impl<'ctx> Evaluator<'ctx> {
             local_vars: RefCell::new(Default::default()),
             lazy_reassign: RefCell::new(false),
             loop_vars: RefCell::new(Default::default()),
+            config_entry_vars: RefCell::new(Default::default()),
             backtrack_meta: RefCell::new(Default::default()),
             ast_id: RefCell::new(AstIndex::default()),
             ctx_stack: RefCell::new(Default::default()),

--- a/crates/evaluator/src/node.rs
+++ b/crates/evaluator/src/node.rs
@@ -992,7 +992,9 @@ impl<'ctx> TypedResultWalker<'ctx> for Evaluator<'ctx> {
     #[inline]
     fn walk_config_expr(&self, config_expr: &'ctx ast::ConfigExpr) -> Self::Result {
         self.enter_scope();
+        self.enter_config_entry_scope();
         defer! {
+            self.leave_config_entry_scope();
             self.leave_scope();
         }
 
@@ -1766,6 +1768,9 @@ impl<'ctx> Evaluator<'ctx> {
     pub(crate) fn walk_config_entries(&self, items: &'ctx [NodeRef<ConfigEntry>]) -> EvalResult {
         let mut config_value = self.dict_value();
         for item in items {
+            // Nested schema bodies clear the local variable marks, so re-assert
+            // the ones owned by this config scope before reading the next entry.
+            self.restore_config_entry_vars();
             let value = self.walk_expr(&item.node.value)?;
             if let Some(key_node) = &item.node.key {
                 let mut insert_index = None;
@@ -1812,6 +1817,12 @@ impl<'ctx> Evaluator<'ctx> {
                 if let Some(name) = &optional_name {
                     let value = self.dict_get_value(&config_value, name);
                     self.add_or_update_local_variable_within_scope(name, value);
+                    // The entry is now bound in the current config scope, so the
+                    // following sibling entries must read it from there. Without
+                    // this mark, a name that also exists as an attribute of an
+                    // enclosing schema would be resolved against that schema
+                    // instead of the value just assigned here.
+                    self.mark_config_entry_var(name);
                 }
             } else {
                 // If the key does not exist, execute the logic of unpacking expression `**expr` here.

--- a/crates/evaluator/src/tests.rs
+++ b/crates/evaluator/src/tests.rs
@@ -1266,6 +1266,61 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::thread;
 
+/// Regression test for kcl-lang/kcl#1769: a config entry inside a schema must
+/// shadow a same-named attribute of the enclosing schema for the entries that
+/// follow it. Without the fix, `q: p + 1` resolved `p` against the enclosing
+/// `Outer.p` (100) instead of the just-assigned `Item.p` (101) and produced
+/// `q: 101`. With the fix the inner assignment shadows the outer name and
+/// `q: 102` is observed, matching the golden output in
+/// `tests/grammar/schema/config_entry_scope/stdout.golden`.
+#[test]
+fn test_config_entry_shadows_enclosing_schema_attr() {
+    let p = load_packages(&LoadPackageOptions {
+        paths: vec!["test.k".to_string()],
+        load_opts: Some(LoadProgramOptions {
+            k_code_list: vec![
+                r#"
+schema Item:
+    p: int
+    q: int
+
+schema Outer:
+    p: int
+    item: any = Item {
+        p: p + 1
+        q: p + 1
+    }
+    after: int = p
+
+outer = Outer { p: 100 }
+"#
+                .to_string(),
+            ],
+            ..Default::default()
+        }),
+        load_builtin: false,
+        ..Default::default()
+    })
+    .unwrap();
+    let evaluator = Evaluator::new(&p.program);
+    let (output, _) = evaluator.run().unwrap();
+    assert!(
+        output.contains(r#""p": 101"#),
+        "expected item.p = 101, got: {}",
+        output
+    );
+    assert!(
+        output.contains(r#""q": 102"#),
+        "expected item.q = 102 (shadowing of outer p by inner p), got: {}",
+        output
+    );
+    assert!(
+        output.contains(r#""after": 100"#),
+        "expected outer.after = 100 (shadowing must not outlive the config), got: {}",
+        output
+    );
+}
+
 const MULTI_THREAD_SOURCE: &str = r#"
 import regex
 foo = option("foo")

--- a/tests/grammar/schema/config_entry_scope/main.k
+++ b/tests/grammar/schema/config_entry_scope/main.k
@@ -1,0 +1,36 @@
+schema Item:
+    p: int
+    q: int
+
+schema Nested:
+    a: int
+    b: int
+
+schema Mid:
+    a: int
+    nested: any
+    c: int
+
+# A config entry must shadow an attribute of the same name in the enclosing
+# schema for the entries that follow it. See issue #1769.
+schema Outer:
+    p: int
+    item: any = Item {
+        p: p + 1
+        q: p + 1
+    }
+    # The shadowing must not outlive the config expression.
+    after: int = p
+
+# The shadowing must survive the evaluation of a nested schema body and must be
+# restored to the enclosing config entry when that nested config is left.
+schema Top:
+    a: int
+    mid: any = Mid {
+        a: a + 1
+        nested: Nested { a: 50, b: a }
+        c: a
+    }
+
+outer = Outer { p: 100 }
+top = Top { a: 10 }

--- a/tests/grammar/schema/config_entry_scope/stdout.golden
+++ b/tests/grammar/schema/config_entry_scope/stdout.golden
@@ -1,0 +1,14 @@
+outer:
+  p: 100
+  item:
+    p: 101
+    q: 102
+  after: 100
+top:
+  a: 10
+  mid:
+    a: 11
+    nested:
+      a: 50
+      b: 50
+    c: 11


### PR DESCRIPTION
## Summary

Closes kcl-lang/kcl#1769. Inside a config expression nested under another schema, a name that is also an attribute of the enclosing schema was always resolved against the enclosing schema, even when an earlier sibling entry had just rebound the name in the current config scope. Concretely, given

```kcl
schema Outer:
    p: int
    item: any = Item {
        p: p + 1   # assigns Item.p = Outer.p + 1 = 101
        q: p + 1   # expected to see the just-set Item.p = 101 → q = 102
    }
    after: int = p  # the shadow must not outlive the config

outer = Outer { p: 100 }
```

the evaluator previously returned `q: 101` because `p` in `q: p + 1` was resolved against `Outer.p` (100). The user-visible symptom in #1769 was a `Fold` schema whose recursive step silently produced the wrong sum instead of raising the expected "list index out of range" error when its `l` argument had been reassigned to `l[1::]`.

## Fix

`Evaluator::walk_config_entries` (`crates/evaluator/src/node.rs`) already routes names tagged as `local_vars` through the lexical scope in `load_name`, and `walk_config_entries` already binds each entry into the current scope via `add_or_update_local_variable_within_scope`. The bug was that the entry name was never *registered* as a `local_var`, so `SchemaEvalContext::get_value` kept returning the enclosing schema attribute. Mark each entry after its value is walked:

- `is_local_var` then returns true for that name, so `load_name` falls through to `get_variable` instead of `get_variable_in_schema_or_rule`.
- The shadow is removed when the config expression is left, so siblings outside the config still see the schema attribute.
- Marks are tracked per config scope so nested configs can shadow their own outer config, and the outer marks are restored cleanly when the nested config is left.
- `restore_config_entry_vars` re-asserts the marks before each entry, because nested schema bodies call `clear_local_vars` and would otherwise wipe them between sibling entries.

The grammar golden `tests/grammar/schema/config_entry_scope/stdout.golden` now matches the actual output:

```
outer:
  p: 100
  item:
    p: 101
    q: 102
  after: 100
```

The user's original reproducer from #1769 also starts raising the expected `list index out of range: 0` error on the recursive `acc: func(acc, l[0])` line once `l: l[1::]` has emptied the list.

## Test plan

- [x] `cargo test -p kcl-evaluator --lib` — 107 passed (106 pre-existing + 1 new regression test that builds an `Evaluator` directly so the assertion does not depend on having a freshly built `libkcl` binary on disk).
- [x] `pytest tests/grammar/test_grammar.py -k config_entry_scope` — passes against the golden file in `tests/grammar/schema/config_entry_scope/stdout.golden`.
- [x] Manually verified the user's `Fold` reproducer from #1769 now errors out with `list index out of range: 0` on the second iteration once `l: l[1::]` has dropped the first element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)