### PR TITLE
fix(evaluator): don't replay setter statements whose effect already applied (fixes #1833)

### DIFF
--- a/crates/evaluator/src/lazy.rs
+++ b/crates/evaluator/src/lazy.rs
@@ -54,9 +54,42 @@ pub struct LazyEvalScope {
     /// Keys whose cached value was resolved from a later setter via backtracking.
     /// An earlier-precedence setter must not overwrite such a resolved entry.
     pub resolved: IndexSet<String>,
+    /// AST ids of the statements the eager (non-backtracking) walk has already
+    /// entered. Used by [`Self::setters_already_run`].
+    pub entered_stmts: IndexSet<AstIndex>,
 }
 
 impl LazyEvalScope {
+    /// Whether every setter of `key` belongs to a statement that the eager walk
+    /// has already entered, and `key` has already been assigned at least once.
+    ///
+    /// When that holds, the variable in scope already carries the value produced
+    /// by every setter that can still run, so backtracking would only replay
+    /// statements whose effect is already applied — duplicating their side
+    /// effects (`print` output, `+=` accumulation, ...). See issue #1833.
+    ///
+    /// A single statement routinely contributes several setters for the same
+    /// key: an `if`/`else` nested inside an outer `if` emits one setter per
+    /// branch, both pointing at the same outer statement, yet only one branch
+    /// can ever run. The per-assignment counter in [`Self::cal_increment`] then
+    /// never reaches the setter count and the value is never cached, so every
+    /// read triggers a replay.
+    ///
+    /// The `cal_times` guard keeps genuine forward references (a read that
+    /// happens before any setter assigned the key) on the normal backtracking
+    /// path, where the replay is what produces the value in the first place.
+    pub fn setters_already_run(&self, key: &str) -> bool {
+        if *self.cal_times.get(key).unwrap_or(&0) == 0 {
+            return false;
+        }
+        match self.setters.get(key) {
+            Some(setters) if !setters.is_empty() => setters
+                .iter()
+                .all(|setter| self.entered_stmts.contains(&setter.stmt_id)),
+            _ => false,
+        }
+    }
+
     #[inline]
     pub fn is_backtracking(&self, key: &str) -> bool {
         let level = self.levels.get(key).unwrap_or(&0);
@@ -341,7 +374,20 @@ impl<'ctx> Evaluator<'ctx> {
                         let scope = lazy_scopes.get(pkgpath).expect(INTERNAL_ERROR_MSG);
                         scope.setters.get(key).cloned()
                     };
+                    let already_run = {
+                        let lazy_scopes = self.lazy_scopes.borrow();
+                        let scope = lazy_scopes.get(pkgpath).expect(INTERNAL_ERROR_MSG);
+                        scope.setters_already_run(key)
+                    };
                     match &setters {
+                        // Every setter that can still run has already run, so the
+                        // variable holds the value the reader expects. Replaying
+                        // them would only duplicate side effects. See issue #1833.
+                        // The value is deliberately not cached: later setters of
+                        // the same statement may still refine it.
+                        Some(setters) if !setters.is_empty() && already_run => {
+                            self.get_variable_in_pkgpath(key, pkgpath)
+                        }
                         Some(setters) if !setters.is_empty() => {
                             // Call all setters function to calculate the value recursively.
                             let level = {
@@ -417,6 +463,22 @@ impl<'ctx> Evaluator<'ctx> {
             && scope.cache.get(key).is_none()
         {
             scope.cache.insert(key.to_string(), value.clone());
+        }
+    }
+
+    /// Record that the eager (non-backtracking) walk has entered the statement
+    /// `stmt_id`, so [`LazyEvalScope::setters_already_run`] can tell that its
+    /// setters no longer need to be replayed.
+    #[inline]
+    pub(crate) fn mark_stmt_entered(&self, stmt_id: &AstIndex) {
+        // Only the eager pass establishes values; replays must not count.
+        if !self.backtrack_meta.borrow().is_empty() {
+            return;
+        }
+        let pkgpath = self.current_pkgpath();
+        let mut lazy_scopes = self.lazy_scopes.borrow_mut();
+        if let Some(scope) = lazy_scopes.get_mut(&pkgpath) {
+            scope.entered_stmts.insert(stmt_id.clone());
         }
     }
 

--- a/crates/evaluator/src/node.rs
+++ b/crates/evaluator/src/node.rs
@@ -65,6 +65,7 @@ impl<'ctx> TypedResultWalker<'ctx> for Evaluator<'ctx> {
             self.update_ctx_panic_info(stmt);
         }
         self.update_ast_id(stmt);
+        self.mark_stmt_entered(&stmt.id);
         let value = match &stmt.node {
             ast::Stmt::TypeAlias(type_alias) => self.walk_type_alias_stmt(type_alias),
             ast::Stmt::Expr(expr_stmt) => self.walk_expr_stmt(expr_stmt),

--- a/crates/evaluator/src/schema.rs
+++ b/crates/evaluator/src/schema.rs
@@ -154,6 +154,7 @@ impl SchemaEvalContext {
                     cal_times: other.cal_times.clone(),
                     setters: other.setters.clone(),
                     resolved: other.resolved.clone(),
+                    entered_stmts: other.entered_stmts.clone(),
                 })))
             }
         }

--- a/crates/evaluator/src/tests.rs
+++ b/crates/evaluator/src/tests.rs
@@ -1612,3 +1612,118 @@ bar = _bar
         log
     );
 }
+
+#[test]
+fn test_issue_1833_nested_if_else_no_replayed_side_effects() {
+    // Regression test for issue https://github.com/kcl-lang/kcl/issues/1833
+    // An `if`/`else` nested inside an outer `if` emits one setter per branch,
+    // both pointing at the same outer statement, yet only one branch can ever
+    // run. The per-assignment counter therefore never reached the setter count,
+    // the value was never cached, and every read of `_namespace` / `_items`
+    // replayed the whole outer statement — re-running the `print` calls.
+    let p = load_packages(&LoadPackageOptions {
+        paths: vec!["test.k".to_string()],
+        load_opts: Some(LoadProgramOptions {
+            k_code_list: vec![
+                r#"_oxr: {str:} = {
+    metadata = {name = "fastapi-gateway"}
+    spec = {}
+}
+print("running main")
+if _oxr.spec.values == Undefined:
+    print("In if")
+    if not _oxr.metadata.labels:
+        _namespace = "default_namespace"
+    else:
+        _namespace = _oxr.metadata.labels["crossplane.io/claim-namespace"]
+    print(_namespace)
+    _items = [{"namespace": _namespace}]
+else:
+    print("in else")
+    _items = []
+
+items = _items
+"#
+                .to_string(),
+            ],
+            ..Default::default()
+        }),
+        load_builtin: false,
+        ..Default::default()
+    })
+    .unwrap();
+    let evaluator = Evaluator::new(&p.program);
+    let (output, _) = evaluator.run().expect("program must evaluate successfully");
+    // Before the fix the log repeated "In if" three times and "default_namespace" twice.
+    let log = evaluator.runtime_ctx.borrow().log_message.clone();
+    assert_eq!(
+        log, "running main\nIn if\ndefault_namespace\n",
+        "each statement must run exactly once; got log:\n{}",
+        log
+    );
+    assert_eq!(output, r#"{"items": [{"namespace": "default_namespace"}]}"#);
+}
+
+#[test]
+fn test_issue_1833_read_inside_if_does_not_replay_aug_assign() {
+    // Regression test for issue https://github.com/kcl-lang/kcl/issues/1833
+    // Reading a variable in the middle of the `if` statement that owns its
+    // setters used to replay that statement, applying `_a += 1` twice and
+    // yielding `b = 3` instead of `b = 2` (and printing "mid" twice).
+    let p = load_packages(&LoadPackageOptions {
+        paths: vec!["test.k".to_string()],
+        load_opts: Some(LoadProgramOptions {
+            k_code_list: vec![
+                r#"if True:
+    _a = 1
+    print("mid ${_a}")
+    _a += 1
+b = _a
+"#
+                .to_string(),
+            ],
+            ..Default::default()
+        }),
+        load_builtin: false,
+        ..Default::default()
+    })
+    .unwrap();
+    let evaluator = Evaluator::new(&p.program);
+    let (output, _) = evaluator.run().expect("program must evaluate successfully");
+    let log = evaluator.runtime_ctx.borrow().log_message.clone();
+    assert_eq!(
+        log, "mid 1\n",
+        "the `if` body must run exactly once; got log:\n{}",
+        log
+    );
+    assert_eq!(output, r#"{"b": 2}"#);
+}
+
+#[test]
+fn test_issue_1833_forward_reference_still_backtracks() {
+    // Companion to the tests above: a genuine forward reference (the read
+    // happens before any setter assigned the key) must keep using the
+    // backtracking path, otherwise it would resolve to `Undefined`.
+    let p = load_packages(&LoadPackageOptions {
+        paths: vec!["test.k".to_string()],
+        load_opts: Some(LoadProgramOptions {
+            k_code_list: vec![
+                r#"if True:
+    if True:
+        _x = 1
+    else:
+        _x = 2
+b = _x
+"#
+                .to_string(),
+            ],
+            ..Default::default()
+        }),
+        load_builtin: false,
+        ..Default::default()
+    })
+    .unwrap();
+    let evaluator = Evaluator::new(&p.program);
+    let (output, _) = evaluator.run().expect("program must evaluate successfully");
+    assert_eq!(output, r#"{"b": 1}"#);
+}


### PR DESCRIPTION
Fixes #1833.

Reading a variable in a nested `if` used to re-run the whole outer statement,
so `print(_x)` inside a `if True: ...` branch emitted multiple lines and
`_x += 1` accumulated twice (`b == 3` instead of `2`).

Root cause: an `if`/`else` nested inside an outer `if` emits one setter per
branch, both pointing at the same outer statement, yet only one branch can
ever run. The per-assignment counter in `cal_increment` therefore never reached
the setter count, the value was never cached, and every read of the variable
replayed the whole outer statement.

Fix: track the AST ids of statements the eager walk has entered. When every
setter of a key belongs to such a statement *and* the key has already been
assigned at least once, return the live value instead of backtracking. The
`cal_times` guard keeps genuine forward references (a read before any setter
ran) on the backtracking path, where the replay is what produces the value.

Three regression tests cover the reported symptom, the `+=` value bug, and a
companion forward-reference case (still must backtrack).