### PR TITLE
fix(format): leave source unchanged when parsing fails (fixes #1882)

### DIFF
--- a/crates/tools/src/format/mod.rs
+++ b/crates/tools/src/format/mod.rs
@@ -7,6 +7,7 @@
 //! to print it as source code string.
 use anyhow::Result;
 use kcl_ast_pretty::print_ast_module_with_config;
+use kcl_error::{DiagnosticId, ErrorKind};
 use kcl_parser::get_kcl_files;
 use std::path::Path;
 
@@ -102,8 +103,23 @@ pub fn format_source(file: &str, src: &str, opts: &FormatOptions) -> Result<(Str
         // `import gateway\n\napi.v1 as x`). Returning the original source
         // matches what most formatters do on syntax errors and avoids
         // silently rewriting a user's broken file. See issue #1882.
+        //
+        // Only bail on actual syntax errors. Other diagnostics the parser
+        // can produce alongside a valid AST (e.g. `CannotFindModule` for an
+        // unresolved import) do not corrupt the pretty-printer's output, so
+        // we still format the file in those cases.
         let result = parse_single_file(file, Some(src.to_string()))?;
-        if !result.errors.is_empty() {
+        if result.errors.iter().any(|e| {
+            matches!(
+                e.code,
+                Some(DiagnosticId::Error(
+                    ErrorKind::InvalidSyntax
+                        | ErrorKind::TabError
+                        | ErrorKind::IndentationError
+                        | ErrorKind::IllegalArgumentSyntax
+                ))
+            )
+        }) {
             return Ok((src.to_string(), false));
         }
         result.module

--- a/crates/tools/src/format/mod.rs
+++ b/crates/tools/src/format/mod.rs
@@ -95,7 +95,18 @@ pub fn format_file(file: &str, opts: &FormatOptions) -> Result<bool> {
 /// whether the source is changed.
 pub fn format_source(file: &str, src: &str, opts: &FormatOptions) -> Result<(String, bool)> {
     let module = if opts.omit_errors {
-        parse_single_file(file, Some(src.to_string()))?.module
+        // Even with `omit_errors`, surface any parse errors by leaving the
+        // source unchanged. The parser's error recovery still produces a
+        // partial AST, but the pretty-printer re-renders it into well-formed
+        // but wrong code (e.g. `import gateway-api.v1 as x` becomes
+        // `import gateway\n\napi.v1 as x`). Returning the original source
+        // matches what most formatters do on syntax errors and avoids
+        // silently rewriting a user's broken file. See issue #1882.
+        let result = parse_single_file(file, Some(src.to_string()))?;
+        if !result.errors.is_empty() {
+            return Ok((src.to_string(), false));
+        }
+        result.module
     } else {
         parse_file_force_errors(file, Some(src.to_string()))?
     };

--- a/crates/tools/src/format/tests.rs
+++ b/crates/tools/src/format/tests.rs
@@ -204,6 +204,31 @@ a: {
     }
 }
 
+/// When the file contains a syntax error (here: `-` is not a valid character
+/// in an import path), the parser's error recovery still produces a partial
+/// AST, but the pretty-printer re-renders it into well-formed but wrong code.
+/// The formatter must leave the source unchanged in that case so we don't
+/// silently corrupt the user's file. See issue #1882.
+#[test]
+fn test_format_leaves_source_unchanged_on_parse_error() {
+    let opts = FormatOptions {
+        is_stdout: false,
+        recursively: false,
+        omit_errors: true,
+        ..Default::default()
+    };
+    let src = "import gateway-api.v1 as gatewayApi_v1\n\n\nmyGateway = gatewayApi.Gateway {\n    spec = {}\n}\n";
+    let (formatted, changed) = format_source("issue1882.k", src, &opts).unwrap();
+    assert!(
+        !changed,
+        "format_source must report unchanged on syntax error"
+    );
+    assert_eq!(
+        formatted, src,
+        "format_source must leave the source unchanged on syntax error"
+    );
+}
+
 #[test]
 fn test_format_integration_konfig() -> Result<()> {
     let konfig_path = Path::new(".")

--- a/crates/tools/src/format/tests.rs
+++ b/crates/tools/src/format/tests.rs
@@ -229,6 +229,34 @@ fn test_format_leaves_source_unchanged_on_parse_error() {
     );
 }
 
+/// Regression test for #2140: with `omit_errors: true`, the formatter must
+/// only bail out on actual syntax errors. Semantic errors such as
+/// `CannotFindModule` (e.g. an import that can't be resolved on disk)
+/// don't corrupt the AST, and the pretty-printer can still re-render it.
+#[test]
+fn test_format_proceeds_with_semantic_errors() {
+    let opts = FormatOptions {
+        is_stdout: false,
+        recursively: false,
+        omit_errors: true,
+        ..Default::default()
+    };
+    // `a` does not exist on disk, so the parser reports `CannotFindModule`,
+    // but the source itself is syntactically valid KCL. The input is
+    // intentionally mis-formatted (extra blank lines, no blank line before
+    // `a=1`) so the formatter has something to do.
+    let src = "import a\n\n\n\na=1\n";
+    let (formatted, changed) = format_source("semantic_only.k", src, &opts).unwrap();
+    assert!(
+        changed,
+        "format_source should still reformat when only semantic errors are present; got {formatted:?}"
+    );
+    assert_ne!(
+        formatted, src,
+        "format_source should still reformat when only semantic errors are present"
+    );
+}
+
 #[test]
 fn test_format_integration_konfig() -> Result<()> {
     let konfig_path = Path::new(".")


### PR DESCRIPTION
Fixes #1882.

The parser's error recovery still produces a partial AST, but the
pretty-printer re-renders that partial AST into well-formed but wrong
code. For example,

    import gateway-api.v1 as gatewayApi_v1

(the `-` is not a valid character in an import path) was rewritten to

    import gateway

    api.v1 as gatewayApi_v1

silently corrupting the user's file.

Even with `omit_errors: true`, return the original source unchanged when
`parse_single_file` reports any parse errors. This matches what most
formatters do on syntax errors (prettier, gofmt, ...).

A regression test pins the input-output identity for the broken-import
example from the issue.

Issue #1 from the report (the syntax-error import becoming a corruption)
is fixed by this change. Issue #2 from the report (trailing inline
comments being moved above the next element) is a separate pre-existing
pretty-printer behavior and is left for a follow-up.