### PR TITLE
fix(evaluator): handle no-op setter replay for if/elif mixin branches (fixes #1835)

### DIFF
--- a/crates/evaluator/src/schema.rs
+++ b/crates/evaluator/src/schema.rs
@@ -454,28 +454,44 @@ impl SchemaEvalContext {
                         };
                         match &setters {
                             Some(setters) if !setters.is_empty() => {
-                                // Call all setters function to calculate the value recursively.
+                                // Backtrack through the setter list until a setter that
+                                // actually assigns `key` is found. A single statement can
+                                // emit several setters for the same key — most notably an
+                                // `if ... elif ...` chain emits one `If` and one `OrElse`
+                                // setter, both pointing at the outer statement. When the
+                                // outer `if` branch's condition is true, replaying the
+                                // `OrElse` setter is a no-op (the
+                                // `backtrack_only_or_else` walk returns immediately), but
+                                // the loop originally still cached the still-`Undefined`
+                                // default value — losing the value the `If` setter would
+                                // have produced. See issue #1835.
+                                //
+                                // Instead of caching whatever `self.value[key]` happens
+                                // to be after a single setter walk, walk successive setters
+                                // (in reverse, i.e. from the latest to the earliest) until
+                                // one actually writes to `key`. If every setter turns out
+                                // to be a no-op, fall back to the pre-backtrack `value`.
                                 let level = {
                                     let scope = scope.borrow();
                                     *scope.levels.get(key).unwrap_or(&0)
                                 };
-                                let next_level = level + 1;
-                                {
-                                    let mut scope = scope.borrow_mut();
-                                    scope.levels.insert(key.to_string(), next_level);
-                                }
                                 let n = setters.len();
-                                // Guard the subtraction: when the backtrack has exhausted
-                                // every setter for this key, fall back to the cached value
-                                // rather than panicking on a `usize` underflow.
-                                if next_level > n {
-                                    value
-                                } else {
-                                    let index = n - next_level;
+                                let mut current_level = level + 1;
+                                let mut resolved_value: ValueRef = value.clone();
+                                loop {
+                                    // Guard the subtraction: when the backtrack has
+                                    // exhausted every setter for this key, fall back to
+                                    // the cached value rather than panicking on a `usize`
+                                    // underflow.
+                                    if current_level > n {
+                                        break;
+                                    }
+                                    let index = n - current_level;
                                     // Track this lazy-replay so the eager `call_schema_body`
                                     // loop in `schema_body` can skip it instead of applying
-                                    // the same mixin setter a second time. Only count setters
-                                    // whose origin frame is one of this host's mixins.
+                                    // the same mixin setter a second time. Only count
+                                    // setters whose origin frame is one of this host's
+                                    // mixins.
                                     if let Some(mixin_idx) = setters[index].index {
                                         if let Some(name) = self.mixin_name_by_frame(mixin_idx) {
                                             let mut applied = self.applied_mixins.borrow_mut();
@@ -483,22 +499,36 @@ impl SchemaEvalContext {
                                             *entry += 1;
                                         }
                                     }
+                                    {
+                                        let mut scope = scope.borrow_mut();
+                                        scope.levels.insert(key.to_string(), current_level);
+                                    }
                                     // Call setter function
                                     s.walk_schema_stmts_with_setter(
                                         &self.node.body,
                                         &setters[index],
                                     )
                                     .expect(kcl_error::INTERNAL_ERROR_MSG);
-                                    {
-                                        let mut scope = scope.borrow_mut();
-                                        scope.levels.insert(key.to_string(), level);
-                                        let value = match self.value.get_by_key(key) {
-                                            Some(value) => value.clone(),
-                                            None => s.undefined_value(),
-                                        };
-                                        scope.cache.insert(key.to_string(), value.clone());
-                                        value
+                                    let new_value = match self.value.get_by_key(key) {
+                                        Some(value) => value.clone(),
+                                        None => s.undefined_value(),
+                                    };
+                                    // Did the setter actually assign the key? Only then
+                                    // is this the value we want to cache. An `Undefined`
+                                    // here means the walk was a no-op (e.g. an `OrElse`
+                                    // replay whose `if` condition was truth) and we
+                                    // must keep backtracking to the next setter.
+                                    if !new_value.is_undefined() {
+                                        resolved_value = new_value;
+                                        break;
                                     }
+                                    current_level += 1;
+                                }
+                                {
+                                    let mut scope = scope.borrow_mut();
+                                    scope.levels.insert(key.to_string(), level);
+                                    scope.cache.insert(key.to_string(), resolved_value.clone());
+                                    resolved_value
                                 }
                             }
                             _ => value,

--- a/crates/evaluator/src/tests.rs
+++ b/crates/evaluator/src/tests.rs
@@ -1612,3 +1612,113 @@ bar = _bar
         log
     );
 }
+
+#[test]
+fn test_issue_1835_mixin_if_elif_unsetting() {
+    // Regression test for issue https://github.com/kcl-lang/kcl/issues/1835
+    //
+    // An `if ... elif ...` chain inside a mixin emits two setters for the
+    // shared outer statement: one `If` and one `OrElse`. When the first
+    // branch's condition is true, the `OrElse` replay is a no-op (the
+    // `backtrack_only_or_else` walk returns immediately). The original
+    // `SchemaEvalContext::get_value` then cached the still-`Undefined`
+    // value from the lazy-scope default instead of continuing to walk the
+    // setter on the `If` branch, so reads of the variable resolved to
+    // `Undefined` (or to the `or` fallback) instead of the accumulated
+    // list.
+    //
+    // The simpler `OneCondMixin` (one `if`, no `elif`) does not trip the
+    // bug because it has one fewer setter, so the `If` replay is the
+    // backtrack entry-point and the `Undefined` is never cached.
+    let p = load_packages(&LoadPackageOptions {
+        paths: vec!["test.k".to_string()],
+        load_opts: Some(LoadProgramOptions {
+            k_code_list: vec![
+                r#"mixin OneCondMixin:
+    _a: [str] = []
+    _a += ["text1"]
+    if mod == "m":
+        _a += ["text2"]
+
+mixin TwoCondMixin:
+    _a: [str] = []
+    _a += ["text1"]
+    if mod == "m":
+        _a += ["text2"]
+    elif mod == "n":
+        _a += ["text3"]
+
+schema OneCondSchema:
+    mixin [OneCondMixin]
+    mod: str
+    a: [str] = _a or ["dummy"]
+
+schema TwoCondSchema:
+    mixin [TwoCondMixin]
+    mod: str
+    a: [str] = _a or ["dummy"]
+
+ocs = OneCondSchema { mod = "m" }
+tcs = TwoCondSchema { mod = "m" }
+"#
+                .to_string(),
+            ],
+            ..Default::default()
+        }),
+        load_builtin: false,
+        ..Default::default()
+    })
+    .unwrap();
+    let evaluator = Evaluator::new(&p.program);
+    let (output, _) = evaluator.run().expect("program must evaluate successfully");
+    // Both schemas must produce the accumulated list, not the `or`
+    // fallback. Before the fix `tcs.a` was `["dummy"]`.
+    assert_eq!(
+        output,
+        r#"{"ocs": {"mod": "m", "a": ["text1", "text2"]}, "tcs": {"mod": "m", "a": ["text1", "text2"]}}"#
+    );
+}
+
+#[test]
+fn test_issue_1835_mixin_if_elif_unsetting_else_branch() {
+    // Companion: when the *first* branch is false and the elif branch
+    // picks the value, the `If` replay is the no-op and the `OrElse`
+    // replay must drive the value. This exercises the path where the
+    // no-op detector has to skip an `If` setter, not an `OrElse` setter.
+    // When neither branch matches, the accumulated default list remains.
+    let p = load_packages(&LoadPackageOptions {
+        paths: vec!["test.k".to_string()],
+        load_opts: Some(LoadProgramOptions {
+            k_code_list: vec![
+                r#"mixin TwoCondMixin:
+    _a: [str] = []
+    _a += ["text1"]
+    if mod == "m":
+        _a += ["text2"]
+    elif mod == "n":
+        _a += ["text3"]
+
+schema TwoCondSchema:
+    mixin [TwoCondMixin]
+    mod: str
+    a: [str] = _a or ["dummy"]
+
+tcs_m = TwoCondSchema { mod = "m" }
+tcs_n = TwoCondSchema { mod = "n" }
+tcs_z = TwoCondSchema { mod = "z" }
+"#
+                .to_string(),
+            ],
+            ..Default::default()
+        }),
+        load_builtin: false,
+        ..Default::default()
+    })
+    .unwrap();
+    let evaluator = Evaluator::new(&p.program);
+    let (output, _) = evaluator.run().expect("program must evaluate successfully");
+    assert_eq!(
+        output,
+        r#"{"tcs_m": {"mod": "m", "a": ["text1", "text2"]}, "tcs_n": {"mod": "n", "a": ["text1", "text3"]}, "tcs_z": {"mod": "z", "a": ["text1"]}}"#
+    );
+}


### PR DESCRIPTION
When an if ... elif ... chain inside a mixin emits multiple setters for the same key, the lazy-scope backtrack could cache the still-Undefined default after a no-op OrElse replay, losing the value produced by the matching If branch.

Walk successive setters (in reverse) until one actually writes the key, and only cache that value. Add regression tests covering both the matching-first-branch and matching-elif-branch paths.

closes #1835
