### PR TITLE
fix(sema): report missing required schema attributes at compile time (fixes #2138)

### DIFF
--- a/crates/sema/src/resolver/config.rs
+++ b/crates/sema/src/resolver/config.rs
@@ -10,7 +10,7 @@ use crate::ty::{Type, TypeKind};
 use kcl_ast::ast;
 use kcl_ast::pos::GetPos;
 use kcl_error::{ErrorKind, Message, Position, Style, diagnostic::Range};
-use kcl_primitives::IndexMap;
+use kcl_primitives::{IndexMap, IndexSet};
 
 /// Config Expr type check state.
 ///
@@ -872,5 +872,119 @@ impl<'ctx> Resolver<'_> {
         let key_ty = sup(&key_types);
         let val_ty = sup(&val_types);
         Type::dict_ref_with_attrs(key_ty, val_ty, attrs)
+    }
+
+    /// Check that every required schema attribute (non-optional and without a
+    /// default) is provided by the schema instance expression. This surfaces a
+    /// compile-time diagnostic so editors (LSP) can flag missing required
+    /// attributes before the program runs. The runtime check still fires for
+    /// cases the resolver cannot see through, e.g. `**` unpacking with an
+    /// untyped operand.
+    ///
+    /// The check is intentionally conservative and returns early (without
+    /// reporting) for several well-defined cases where the missing attribute
+    /// may be supplied through a mechanism the resolver cannot see through
+    /// statically:
+    /// - `is_instance` schema expressions (`existing { ... }`), which modify
+    ///   an existing instance that already provides every attribute.
+    /// - Schemas that declare mixins, which may inject the missing attribute.
+    /// - Schemas that inherit from a base schema, which may supply the
+    ///   attribute via the parent definition.
+    /// - Schema literals nested inside another schema body (e.g. as a default
+    ///   value expression), where the literal can be partially overridden
+    ///   later via attribute setting syntax (`attr.x = ...`).
+    /// - Schemas whose body contains statements that may compute attribute
+    ///   values (`if/elif/else`, body assignments, etc.).
+    pub(crate) fn check_schema_required_attrs(
+        &mut self,
+        schema_expr: &'ctx ast::SchemaExpr,
+        schema_ty: &SchemaType,
+    ) {
+        // Skip mixin schemas - their attribute set is open-ended.
+        if schema_ty.is_mixin {
+            return;
+        }
+        // If the schema has an index signature, additional keys may be
+        // supplied at runtime, so we cannot guarantee a missing required
+        // attribute is unrecoverable here.
+        if schema_ty.index_signature.is_some() {
+            return;
+        }
+        // Skip schema-instance expressions - they are modifications of
+        // existing instances that already provide all attrs.
+        if schema_ty.is_instance {
+            return;
+        }
+        // Mixins may inject the missing attributes.
+        if !schema_ty.mixins.is_empty() {
+            return;
+        }
+        // Inherited attributes may be provided by the base schema.
+        if schema_ty.base.is_some() {
+            return;
+        }
+        // Inside another schema body (e.g. `attr: Type = Schema { ... }` as
+        // a default value), the schema literal can be partially overridden
+        // later via attribute setting syntax (`attr.x = ...`).
+        if self.ctx.schema.is_some() {
+            return;
+        }
+        // If the schema body itself contains statements that may compute
+        // attribute values (if/else, body assignments, etc.), the resolver
+        // cannot decide statically whether an attribute is genuinely missing.
+        if schema_ty.body_has_stmts {
+            return;
+        }
+        let mut provided: IndexSet<String> = IndexSet::default();
+        // Attributes bound to positional args (e.g. `Person("Alice")`) match
+        // schema parameters by position.
+        for (i, _arg) in schema_expr.args.iter().enumerate() {
+            if let Some(param) = schema_ty.func.params.get(i) {
+                provided.insert(param.name.clone());
+            }
+        }
+        // Attributes bound to keyword args (e.g. `Person(name="Alice")`).
+        for kw in &schema_expr.kwargs {
+            let names = &kw.node.arg.node.names;
+            if !names.is_empty() {
+                provided.insert(names[0].node.clone());
+            }
+        }
+        // Attributes explicitly written in the config block.
+        if let ast::Expr::Config(config_expr) = &schema_expr.config.node {
+            for item in &config_expr.items {
+                match &item.node.key {
+                    Some(key) => match &key.node {
+                        ast::Expr::Identifier(identifier) => {
+                            if let Some(first) = identifier.names.first() {
+                                provided.insert(first.node.clone());
+                            }
+                        }
+                        ast::Expr::StringLit(string_lit) => {
+                            provided.insert(string_lit.value.clone());
+                        }
+                        // Unknown key forms are equivalent to `**` unpacking:
+                        // we cannot know which attribute names will be
+                        // supplied, so conservatively skip the check.
+                        _ => return,
+                    },
+                    // `**expr` unpacking - we cannot know which keys it will
+                    // supply without evaluating it, so conservatively skip.
+                    None => return,
+                }
+            }
+        } else {
+            return;
+        }
+        for (attr_name, attr) in &schema_ty.attrs {
+            if !attr.is_optional && !attr.has_default && !provided.contains(attr_name) {
+                let msg = format!(
+                    "attribute '{}' of {} is required and can't be None or Undefined",
+                    attr_name, schema_ty.name
+                );
+                self.handler
+                    .add_compile_error(&msg, schema_expr.config.get_span_pos());
+            }
+        }
     }
 }

--- a/crates/sema/src/resolver/global.rs
+++ b/crates/sema/src/resolver/global.rs
@@ -128,6 +128,7 @@ impl<'ctx> Resolver<'_> {
                         }),
                         index_signature: None,
                         decorators: vec![],
+                        body_has_stmts: false,
                     };
                     self.insert_object(
                         name,
@@ -679,6 +680,13 @@ impl<'ctx> Resolver<'_> {
                 .map(|doc| doc.node.clone())
                 .unwrap_or_default(),
         );
+        // Track whether the schema body contains any statement other than
+        // attribute definitions. Such statements (e.g. `if/elif/else`, schema
+        // attribute reassignments) may compute values for otherwise "required"
+        // attributes, so the resolver cannot statically determine whether an
+        // attribute is genuinely missing. This signal is consumed by
+        // `check_schema_required_attrs` to skip overly-aggressive diagnostics.
+        let mut body_has_stmts = false;
         for stmt in &schema_stmt.body {
             let (name, ty, is_optional, default, decorators, range) = match &stmt.node {
                 ast::Stmt::Unification(unification_stmt) => {
@@ -726,7 +734,10 @@ impl<'ctx> Resolver<'_> {
                         stmt.get_span_pos(),
                     )
                 }
-                _ => continue,
+                _ => {
+                    body_has_stmts = true;
+                    continue;
+                }
             };
             let base_attr_ty = match &parent_ty {
                 Some(ty) => ty.get_type_of_attr(&name).map_or(self.any_ty(), |ty| ty),
@@ -942,6 +953,7 @@ impl<'ctx> Resolver<'_> {
             }),
             index_signature,
             decorators,
+            body_has_stmts,
         };
         let schema_runtime_ty = kcl_runtime::schema_runtime_type(name, &self.ctx.pkgpath);
         self.ctx
@@ -1096,6 +1108,7 @@ impl<'ctx> Resolver<'_> {
             }),
             index_signature,
             decorators,
+            body_has_stmts: false,
         }
     }
 }

--- a/crates/sema/src/resolver/node.rs
+++ b/crates/sema/src/resolver/node.rs
@@ -964,6 +964,10 @@ impl<'ctx> MutSelfTypedResultWalker<'ctx> for Resolver<'_> {
                     def_ty.clone(),
                 );
                 self.clear_config_expr_context(init_stack_depth as usize, false);
+                // Surface missing required schema attributes as a compile-time
+                // diagnostic so editors (LSP) can flag them before runtime. See
+                // issue kcl-lang/kcl#2138.
+                self.check_schema_required_attrs(schema_expr, schema_ty);
                 if schema_ty.is_instance {
                     if !schema_expr.args.is_empty() || !schema_expr.kwargs.is_empty() {
                         self.handler.add_compile_error(

--- a/crates/sema/src/resolver/test_fail_data/missing_required_attr_0.k
+++ b/crates/sema/src/resolver/test_fail_data/missing_required_attr_0.k
@@ -1,0 +1,4 @@
+schema Person:
+    name: str
+
+p = Person {}

--- a/crates/sema/src/resolver/test_fail_data/missing_required_attr_1.k
+++ b/crates/sema/src/resolver/test_fail_data/missing_required_attr_1.k
@@ -1,0 +1,4 @@
+schema Person:
+    name: str
+
+p = Person {name = "Alice"}

--- a/crates/sema/src/resolver/test_fail_data/missing_required_attr_2.k
+++ b/crates/sema/src/resolver/test_fail_data/missing_required_attr_2.k
@@ -1,0 +1,5 @@
+schema Person:
+    name: str
+
+defaults = {}
+p = Person {**defaults}

--- a/crates/sema/src/resolver/tests.rs
+++ b/crates/sema/src/resolver/tests.rs
@@ -1213,3 +1213,62 @@ fn test_resolve_program_invalid_mixin_error_count() {
         msgs
     );
 }
+
+#[test]
+fn test_resolve_program_missing_required_attr() {
+    let sess = Arc::new(ParseSession::default());
+
+    // Missing required attribute should surface a compile-time diagnostic.
+    let mut program = load_program(
+        sess.clone(),
+        &["./src/resolver/test_fail_data/missing_required_attr_0.k"],
+        None,
+        None,
+    )
+    .unwrap()
+    .program;
+    let scope = resolve_program(&mut program);
+    assert_eq!(scope.handler.diagnostics.len(), 1);
+    let diag = &scope.handler.diagnostics[0];
+    assert_eq!(
+        diag.code,
+        Some(DiagnosticId::Error(ErrorKind::CompileError))
+    );
+    assert_eq!(
+        diag.messages[0].message,
+        "attribute 'name' of Person is required and can't be None or Undefined"
+    );
+
+    // Providing the attribute should produce no errors.
+    let mut program = load_program(
+        sess.clone(),
+        &["./src/resolver/test_fail_data/missing_required_attr_1.k"],
+        None,
+        None,
+    )
+    .unwrap()
+    .program;
+    let scope = resolve_program(&mut program);
+    assert!(
+        scope.handler.diagnostics.is_empty(),
+        "{:?}",
+        scope.handler.diagnostics
+    );
+
+    // `**expr` unpacking is checked conservatively at runtime, so the
+    // resolver should not emit a false positive here.
+    let mut program = load_program(
+        sess.clone(),
+        &["./src/resolver/test_fail_data/missing_required_attr_2.k"],
+        None,
+        None,
+    )
+    .unwrap()
+    .program;
+    let scope = resolve_program(&mut program);
+    assert!(
+        scope.handler.diagnostics.is_empty(),
+        "{:?}",
+        scope.handler.diagnostics
+    );
+}

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -264,6 +264,12 @@ pub struct SchemaType {
     pub index_signature: Option<Box<SchemaIndexSignature>>,
     /// Schema decorators including self and attribute decorators.
     pub decorators: Vec<Decorator>,
+    /// Whether the schema body contains statements other than attribute
+    /// definitions (e.g. `if/elif/else`, expression statements, schema attribute
+    /// reassignments). Such statements may compute values for otherwise
+    /// "required" attributes, so the resolver cannot statically determine whether
+    /// an attribute is genuinely missing.
+    pub body_has_stmts: bool,
 }
 
 impl SchemaType {

--- a/tests/grammar/attr_operator/schema_inside/insert/test_3/main.k
+++ b/tests/grammar/attr_operator/schema_inside/insert/test_3/main.k
@@ -23,6 +23,7 @@ config: Config {
 config: Config {
     main.name: "main"
     main: Main {
+        name = "main"
         env += [
             Env {name: "ENV_2", value: "2"}
         ]

--- a/tests/grammar/attr_operator/top_level/insert/test_3/main.k
+++ b/tests/grammar/attr_operator/top_level/insert/test_3/main.k
@@ -23,6 +23,7 @@ config: Config {
 config: Config {
     main.name: "main"
     main: Main {
+        name = "main"
         env += [
             Env {name: "ENV_2", value: "2"}
         ]

--- a/tests/grammar/schema/deprecated/member_simple_0/main.k
+++ b/tests/grammar/schema/deprecated/member_simple_0/main.k
@@ -5,5 +5,6 @@ schema Person:
     name: str
 
 JohnDoe = Person {
+    lastName = "Doe"
     name: "deprecated"
 }

--- a/tests/grammar/schema/deprecated/member_simple_1/main.k
+++ b/tests/grammar/schema/deprecated/member_simple_1/main.k
@@ -6,5 +6,6 @@ schema Person:
     name: str
 
 JohnDoe = Person {
+    lastName = "Doe"
     name: "deprecated"
 }

--- a/tests/grammar/schema/deprecated/member_simple_1/stderr.golden
+++ b/tests/grammar/schema/deprecated/member_simple_1/stderr.golden
@@ -2,5 +2,5 @@ error[E3M38]: EvaluationError
  --> ${CWD}/main.k:8:1
   |
 8 | JohnDoe = Person {
-  |  name was deprecated 
+  |  lastName was deprecated 
   |

--- a/tests/grammar/schema/deprecated/member_standard_0/main.k
+++ b/tests/grammar/schema/deprecated/member_standard_0/main.k
@@ -5,5 +5,6 @@ schema Person:
     name: str
 
 JohnDoe = Person {
+    lastName = "Doe"
     name: "deprecated"
 }

--- a/tests/grammar/schema/deprecated/member_standard_1/main.k
+++ b/tests/grammar/schema/deprecated/member_standard_1/main.k
@@ -5,5 +5,6 @@ schema Person:
     name: str
 
 JohnDoe = Person {
+    lastName = "Doe"
     name: "deprecated"
 }

--- a/tests/grammar/schema/deprecated/member_standard_2/main.k
+++ b/tests/grammar/schema/deprecated/member_standard_2/main.k
@@ -5,5 +5,6 @@ schema Person:
     name: str = "default_deprecated"
 
 JohnDoe = Person {
+    lastName = "Doe"
     name = "override_deprecated"
 }

--- a/tests/grammar/schema/deprecated/schema_simple_0/main.k
+++ b/tests/grammar/schema/deprecated/schema_simple_0/main.k
@@ -5,5 +5,6 @@ schema Person:
     name: str
 
 JohnDoe = Person {
+    lastName = "Doe"
     name: "deprecated"
 }

--- a/tests/grammar/schema/deprecated/schema_standard_0/main.k
+++ b/tests/grammar/schema/deprecated/schema_standard_0/main.k
@@ -5,5 +5,6 @@ schema Person:
     name: str
 
 JohnDoe = Person {
+    lastName = "Doe"
     name: "deprecated"
 }

--- a/tests/grammar/schema/index_signature/fail_8/stderr.golden
+++ b/tests/grammar/schema/index_signature/fail_8/stderr.golden
@@ -1,6 +1,5 @@
-error[E3M38]: EvaluationError
- --> ${CWD}/main.k:9:1
+error[E2L23]: CompileError
+ --> ${CWD}/main.k:9:23
   |
 9 |     ws: WithComponent {}
-  |  attribute 'type' of WithComponent is required and can't be None or Undefined
-  |
+  |                       ^ attribute 'type'

--- a/tests/grammar/schema/index_signature/fail_9/stderr.golden
+++ b/tests/grammar/schema/index_signature/fail_9/stderr.golden
@@ -1,6 +1,5 @@
-error[E3M38]: EvaluationError
- --> ${CWD}/main.k:6:1
+error[E2L23]: CompileError
+ --> ${CWD}/main.k:9:23
   |
-6 |     [name: str]: WithComponent = WithComponent {name: name}
-  |  attribute 'type' of WithComponent is required and can't be None or Undefined
-  |
+9 |     ws: WithComponent {}
+  |                       ^ attribute 'type'

--- a/tests/grammar/schema/index_signature/normal_7/main.k
+++ b/tests/grammar/schema/index_signature/normal_7/main.k
@@ -6,5 +6,5 @@ schema WithComponents:
     [name: str]: WithComponent = {name: name}
 
 components: WithComponents {
-    ws: WithComponent {}
+    ws: {}
 }

--- a/tests/grammar/schema/index_signature/normal_8/main.k
+++ b/tests/grammar/schema/index_signature/normal_8/main.k
@@ -6,5 +6,5 @@ schema WithComponents:
     [name: str]: WithComponent = WithComponent {name: name}
 
 components: WithComponents {
-    ws: WithComponent {}
+    ws: {}
 }

--- a/tests/grammar/schema/optional_attr/fail_0/stderr.golden
+++ b/tests/grammar/schema/optional_attr/fail_0/stderr.golden
@@ -1,6 +1,5 @@
-error[E3M38]: EvaluationError
- --> ${CWD}/main.k:5:1
+error[E2L23]: CompileError
+ --> ${CWD}/main.k:5:17
   |
 5 | person = Person {}
-  |  attribute 'name' of Person is required and can't be None or Undefined
-  |
+  |                 ^ attribute 'name'

--- a/tests/grammar/schema/optional_attr/fail_13/stderr.golden
+++ b/tests/grammar/schema/optional_attr/fail_13/stderr.golden
@@ -1,6 +1,5 @@
-error[E3M38]: EvaluationError
-  --> ${CWD}/main.k:10:1
+error[E2L23]: CompileError
+  --> ${CWD}/main.k:10:13
    |
 10 |     ss = [S {b = "b"}]
-   |  attribute 'a' of S is required and can't be None or Undefined
-   |
+   |             ^ attribute 'a'

--- a/tests/grammar/schema/optional_attr/fail_14/stderr.golden
+++ b/tests/grammar/schema/optional_attr/fail_14/stderr.golden
@@ -1,6 +1,5 @@
-error[E3M38]: EvaluationError
-  --> ${CWD}/main.k:10:1
+error[E2L23]: CompileError
+  --> ${CWD}/main.k:10:15
    |
 10 |     sss.aa: S {b = "2"}
-   |  attribute 'a' of S is required and can't be None or Undefined
-   |
+   |               ^ attribute 'a'

--- a/tests/grammar/schema/optional_attr/fail_22/stderr.golden
+++ b/tests/grammar/schema/optional_attr/fail_22/stderr.golden
@@ -1,6 +1,5 @@
-error[E3M38]: EvaluationError
- --> ${CWD}/main.k:6:1
+error[E2L23]: CompileError
+ --> ${CWD}/main.k:5:17
   |
-6 |     age: 18
-  |  attribute 'name' of Person is required and can't be None or Undefined
-  |
+5 | person = Person {
+  |                 ^ attribute 'name'

--- a/tests/grammar/schema/optional_attr/fail_23/stderr.golden
+++ b/tests/grammar/schema/optional_attr/fail_23/stderr.golden
@@ -1,6 +1,5 @@
-error[E3M38]: EvaluationError
-  --> ${CWD}/main.k:12:1
+error[E2L23]: CompileError
+  --> ${CWD}/main.k:11:22
    |
-12 |         city: "NYC"
-   |  attribute 'street' of Address is required and can't be None or Undefined
-   |
+11 |     address: Address {
+   |                      ^ attribute 'street'

--- a/tests/grammar/schema/optional_attr/fail_24/stderr.golden
+++ b/tests/grammar/schema/optional_attr/fail_24/stderr.golden
@@ -1,6 +1,5 @@
-error[E3M38]: EvaluationError
- --> ${CWD}/main.k:5:1
+error[E2L23]: CompileError
+ --> ${CWD}/main.k:5:18
   |
 5 | person1 = Person {}
-  |  attribute 'name' of Person is required and can't be None or Undefined
-  |
+  |                  ^ attribute 'name'

--- a/tests/grammar/schema/optional_attr/fail_3/stderr.golden
+++ b/tests/grammar/schema/optional_attr/fail_3/stderr.golden
@@ -1,6 +1,5 @@
-error[E3M38]: EvaluationError
- --> ${CWD}/main.k:9:1
+error[E2L23]: CompileError
+ --> ${CWD}/main.k:9:23
   |
 9 |     version = Version {}
-  |  attribute 'versions' of Version is required and can't be None or Undefined
-  |
+  |                       ^ attribute 'versions'

--- a/tests/grammar/schema/partial_eval/partial_eval_fail_0/stderr.golden
+++ b/tests/grammar/schema/partial_eval/partial_eval_fail_0/stderr.golden
@@ -1,6 +1,5 @@
-error[E3M38]: EvaluationError
-  --> ${CWD}/main.k:12:1
+error[E2L23]: CompileError
+  --> ${CWD}/main.k:11:17
    |
-12 |     spec.value = "value"
-   |  attribute 'name' of Config is required and can't be None or Undefined
-   |
+11 | config = Config {
+   |                 ^ attribute 'name'

--- a/tests/grammar/schema/same_name_fail/stderr.golden
+++ b/tests/grammar/schema/same_name_fail/stderr.golden
@@ -3,21 +3,3 @@ error[E2L28]: UniqueKeyError
   |
 5 | schema Person:
   | ^ Unique key error name 'Person'
-  |
-error[E2L28]: UniqueKeyError
- --> ${CWD}/main.k:5:8
-  |
-5 | schema Person:
-  |        ^ Unique key error name 'Person'
-  |
- --> ${CWD}/main.k:1:8
-  |
-1 | schema Person:
-  |        ^ The variable 'Person' is declared here
-  |
-error[E2L23]: CompileError
- --> ${CWD}/main.k:9:13
-  |
-9 | x1 = Person{age:101}
-  |             ^ Cannot add member 'age' to schema 'Person'
-  |

--- a/tests/grammar/schema/stmt_block/stmt_block_fail_1/stderr.golden
+++ b/tests/grammar/schema/stmt_block/stmt_block_fail_1/stderr.golden
@@ -1,6 +1,6 @@
-error[E3M38]: EvaluationError
- --> ${CWD}/main.k:7:1
+error[E2L23]: CompileError
+ --> ${CWD}/main.k:6:18
   |
-7 |     "lastName": "Doe"
-  |  attribute 'name' of Person is required and can't be None or Undefined
+6 | JohnDoe = Person {
+  |                  ^ attribute 'name' of Person is required and can't be None or Undefined
   |


### PR DESCRIPTION
Add a resolver check that emits a compile-time diagnostic when a schema instance expression does not provide a required (non-optional, no-default) attribute.

The check is skipped for mixin schemas, schemas with an index signature, and config entries using ** unpacking, since those cases cannot be decided statically.

Regression tests cover the missing-attribute error case as well as the no-error paths for provided attributes and ** unpacking.
