### PR TITLE
fix(evaluator): don't run nested schema check on default value (fixes #1979)

### DIFF
--- a/crates/evaluator/src/node.rs
+++ b/crates/evaluator/src/node.rs
@@ -543,35 +543,34 @@ impl<'ctx> TypedResultWalker<'ctx> for Evaluator<'ctx> {
                 is_override_op && without_index
             };
             if !is_override_attr {
-                let value = match &schema_attr.value {
-                    Some(value) => self.walk_expr(value)?,
-                    None => self.undefined_value(),
-                };
-                if let Some(op) = &schema_attr.op {
-                    match op {
-                        // Union
-                        ast::AugOp::BitOr => {
+                // The user supplied an entry for this attribute. Apply the
+                // default value as a fallback without running type-driven
+                // schema construction: the entry will be unioned next, and
+                // `value_union` already performs the necessary type
+                // conversion on the merged value. The eager type conversion
+                // in `schema_dict_merge` would otherwise build a schema
+                // instance from the (possibly empty or partial) default
+                // and run its check blocks before the entry is merged,
+                // producing spurious failures (issue kcl-lang/kcl#1979).
+                if let Some(default_expr) = &schema_attr.value {
+                    let default_value = self.walk_expr(default_expr)?;
+                    let value = match &schema_attr.op {
+                        Some(ast::AugOp::BitOr) => {
                             let org_value = schema_value
                                 .dict_get_value(name)
                                 .unwrap_or(self.undefined_value());
-                            let value = self.bit_or(org_value, value);
-                            self.schema_dict_merge(
-                                &mut schema_value,
-                                name,
-                                &value,
-                                &ast::ConfigEntryOperation::Override,
-                                None,
-                            );
+                            self.bit_or(org_value, default_value)
                         }
-                        // Assign
-                        _ => self.schema_dict_merge(
-                            &mut schema_value,
-                            name,
-                            &value,
-                            &ast::ConfigEntryOperation::Override,
-                            None,
-                        ),
-                    }
+                        _ => default_value,
+                    };
+                    self.dict_merge_key_value_pair(
+                        &mut schema_value,
+                        name,
+                        &value,
+                        ConfigEntryOperationKind::Override,
+                        None,
+                        false,
+                    );
                 }
             }
             self.value_union(&mut schema_value, &entry);

--- a/crates/evaluator/src/tests.rs
+++ b/crates/evaluator/src/tests.rs
@@ -1892,3 +1892,76 @@ b = _x
     let (output, _) = evaluator.run().expect("program must evaluate successfully");
     assert_eq!(output, r#"{"b": 1}"#);
 }
+
+#[test]
+fn test_issue_1979_nested_schema_default_does_not_misfire_check() {
+    // Issue kcl-lang/kcl#1979: a parent schema attribute typed as a nested
+    // schema with an `= {}` default used to run the child's check block on
+    // the (empty) default before the user-supplied entry was merged,
+    // producing a spurious "len(labels) > 0" failure.
+    let p = load_packages(&LoadPackageOptions {
+        paths: vec!["test.k".to_string()],
+        load_opts: Some(LoadProgramOptions {
+            k_code_list: vec![
+                r#"schema ParentObject:
+    child: ChildObject = {}
+
+schema ChildObject:
+    labels: {str:str}
+    check:
+        len(labels) > 0
+
+output = ParentObject{
+    child: {
+        labels = {"app": "myapp", "env": "prod"}
+    }
+}
+"#
+                .to_string(),
+            ],
+            ..Default::default()
+        }),
+        load_builtin: false,
+        ..Default::default()
+    })
+    .unwrap();
+    let evaluator = Evaluator::new(&p.program);
+    let (output, _) = evaluator
+        .run()
+        .expect("program with nested schema default must not fail its check");
+    assert_eq!(
+        output,
+        r#"{"output": {"child": {"labels": {"app": "myapp", "env": "prod"}}}}"#
+    );
+}
+
+#[test]
+fn test_issue_1979_user_entry_replaces_default_for_list_attr() {
+    // Companion to the test above: when the user supplies an entry for a
+    // list-typed attribute, the supplied entry fully replaces the default.
+    // The fix removes the eager type-driven schema conversion on the
+    // default, but for plain list types the conversion was a no-op, so
+    // override behaviour must be preserved.
+    let p = load_packages(&LoadPackageOptions {
+        paths: vec!["test.k".to_string()],
+        load_opts: Some(LoadProgramOptions {
+            k_code_list: vec![
+                r#"schema Foo:
+    items: [int] = [1, 2, 3]
+
+x = Foo{
+    items = [4, 5]
+}
+"#
+                .to_string(),
+            ],
+            ..Default::default()
+        }),
+        load_builtin: false,
+        ..Default::default()
+    })
+    .unwrap();
+    let evaluator = Evaluator::new(&p.program);
+    let (output, _) = evaluator.run().expect("program must evaluate successfully");
+    assert_eq!(output, r#"{"x": {"items": [4, 5]}}"#);
+}


### PR DESCRIPTION
## Summary

Fixes kcl-lang/kcl#1979.

When a parent schema has a nested-schema attribute with an `= {}` default and the user supplies a fully populated entry, the eager type-driven schema construction used to run the nested schema's body and check blocks on the empty default *before* the user's entry was merged. The check would then fail on incomplete data (e.g. `len(labels) > 0` on `labels = Undefined`), producing a spurious runtime error.

## Repro (from the issue)

```python
schema ParentObject:
    child: ChildObject = {}  # Removing the `= {}` makes this work

schema ChildObject:
    labels: {str:str}
    check:
        len(labels) > 0

output = ParentObject{
    child: {
        labels = {"app": "myapp", "env": "prod"}
    }
}
```

Before: `error[E3M38]: EvaluationError ... object of type 'UndefinedType' has no len()`
After: 

```yaml
output:
  child:
    labels:
      app: myapp
      env: prod
```

## Root cause

`walk_schema_attr` was routing the default value through `schema_dict_merge`, which calls `type_pack_and_check` on the value when the attribute is in the schema's `attr_map`. For a nested schema type, that eagerly constructs a schema instance and runs its body and check — but only on the (empty) default. The user's entry is unioned afterward, so the merge produces the right output value, but the panic from the empty-data check already happened.

## Fix

In `crates/evaluator/src/node.rs`, when the user has supplied an entry for the attribute, apply the default through `dict_merge_key_value_pair` (which performs a plain dict merge without type conversion) and let the subsequent `value_union` perform the necessary type conversion on the merged value, which carries the user's complete data. The eager conversion path is preserved when no entry is supplied, so default-only schemas still validate.

## Tests

- Added `test_issue_1979_nested_schema_default_does_not_misfire_check` for the reported repro.
- Added `test_issue_1979_user_entry_replaces_default_for_list_attr` as a companion test to lock in override semantics for non-schema typed attributes (e.g. `[int]`).
- All 122 evaluator unit tests pass; all 6 runner tests pass. The 4 pre-existing LSP test failures and 20 pre-existing schema-grammar failures are unchanged by this PR (verified by running the same tests on the baseline branch).