### PR TITLE
test(grammar): end-to-end test for empty schema-typed default merge (#1979)

### DIFF
--- a/tests/grammar/schema/default_value/schema_typed_empty_default/main.k
+++ b/tests/grammar/schema/default_value/schema_typed_empty_default/main.k
@@ -1,0 +1,17 @@
+# Issue #1979: an empty config default `{}` for a schema-typed attribute must be
+# merged with the config override before the child schema is type-checked and its
+# check block runs. Previously the empty default was validated on its own and
+# failed ("attribute labels is missing" / check on an undefined value).
+schema ParentObject:
+    child: ChildObject = {}
+
+schema ChildObject:
+    labels: {str:str}
+    check:
+        len(labels) > 0
+
+output = ParentObject {
+    child: {
+        labels = {"app": "myapp", "env": "prod"}
+    }
+}

--- a/tests/grammar/schema/default_value/schema_typed_empty_default/stdout.golden
+++ b/tests/grammar/schema/default_value/schema_typed_empty_default/stdout.golden
@@ -1,0 +1,5 @@
+output:
+  child:
+    labels:
+      app: myapp
+      env: prod


### PR DESCRIPTION
## What this PR does now

The code fix for #1979 has already landed via #2144 (same approach — apply the default with a non-coercing merge and let `value_union` do the coercion on the merged value). I've **rebased this PR onto the fix and reduced it to just an end-to-end grammar test**, which #2144 did not include (it added evaluator unit tests only).

The test runs the originally reported program through `kcl run` and checks the rendered output, guarding the fix at the CLI level:

```kcl
schema ParentObject:
    child: ChildObject = {}
schema ChildObject:
    labels: {str:str}
    check:
        len(labels) > 0
output = ParentObject { child: { labels = {"app": "myapp", "env": "prod"} } }
```

If you'd rather not carry an extra grammar case, feel free to close this — the fix itself is already in. Otherwise it adds an end-to-end regression guard.

## Verification

- Grammar suite passes with the new case on current `main`.