### PR TITLE
feat(api): honour error_format on the C API error envelope

### DIFF
--- a/crates/api/src/capi_test.rs
+++ b/crates/api/src/capi_test.rs
@@ -202,6 +202,121 @@ fn test_c_api_call_exec_program_with_arcanist_error_format_and_bad_kcl() {
     );
 }
 
+/// Invoke a service call from a JSON fixture and return the raw bytes
+/// the C API hands back. Unlike `test_c_api`, this doesn't assume the
+/// payload is a protobuf-encoded `ExecProgramResult`; it captures the
+/// raw byte buffer so callers can inspect `ERROR:` payloads directly.
+fn call_c_api_raw(svc_name: &str, input: &str) -> Vec<u8> {
+    let _test_lock = TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+    let serv = unsafe { kcl_service_new(0) };
+    let input_path = Path::new(TEST_DATA_PATH).join(input);
+    let input = fs::read_to_string(&input_path)
+        .unwrap_or_else(|_| panic!("Something went wrong reading {}", input_path.display()));
+    let args: ExecProgramArgs = serde_json::from_str(&input).unwrap();
+    let args_vec = args.encode_to_vec();
+    let args_cstr = unsafe { CString::from_vec_unchecked(args_vec.clone()) };
+    let call = CString::new(svc_name).unwrap();
+    let mut result_len: usize = 0;
+    let src_ptr = unsafe {
+        kcl_service_call_with_length(
+            serv,
+            call.as_ptr(),
+            args_cstr.as_ptr(),
+            args_vec.len(),
+            &mut result_len,
+        )
+    };
+    let mut dest_data: Vec<u8> = Vec::with_capacity(result_len);
+    unsafe {
+        let dest_ptr: *mut u8 = dest_data.as_mut_ptr();
+        std::ptr::copy_nonoverlapping(src_ptr as *const u8, dest_ptr, result_len);
+        dest_data.set_len(result_len);
+    }
+    unsafe {
+        kcl_service_delete(serv);
+        kcl_service_free_string(src_ptr as *mut c_char);
+    }
+    dest_data
+}
+
+/// Call a service from a JSON fixture and verify the `ERROR:<body>`
+/// payload matches `<input>.response.error` byte-for-byte. Mirrors
+/// `test_c_api` / `test_c_api_panic` but for the `ERROR:` envelope —
+/// the C API returns this instead of a protobuf-encoded result when
+/// the service itself reports failure (e.g. a KCL compile error).
+///
+/// `expected_error_file` is read as plain text; the trailing newline
+/// (if any) is significant and compared verbatim so the fixture
+/// round-trips exactly.
+///
+/// Both sides are normalised before comparison so the test passes
+/// regardless of how line endings end up in each side:
+///
+/// 1. `\r\n` → `\n` covers CRLF bytes (Windows-side text output, or
+///    fixtures checked out with autocrlf on Windows).
+/// 2. The JSON-escape form `\r\n` (i.e. the four bytes `\` `r` `\` `n`,
+///    not actual CR+LF) → `\n` (the two bytes `\` `n`) covers the
+///    SARIF/arcanist payloads, which `serde_json` writes out as their
+///    canonical escape sequence — and which can differ between host
+///    and fixture when the underlying message contains CRLF on Windows.
+fn test_c_api_error(svc_name: &str, input: &str, expected_error_file: &str) {
+    let payload = call_c_api_raw(svc_name, input);
+    let s = std::str::from_utf8(&payload).expect("ERROR payload is not valid UTF-8");
+    let body = s
+        .strip_prefix("ERROR:")
+        .unwrap_or_else(|| panic!("payload missing ERROR: prefix: {s:?}"));
+    let expected_path = Path::new(TEST_DATA_PATH).join(expected_error_file);
+    let expected_raw = fs::read(&expected_path)
+        .unwrap_or_else(|_| panic!("Something went wrong reading {}", expected_path.display()));
+    let expected = std::str::from_utf8(&expected_raw)
+        .unwrap_or_else(|_| panic!("{} is not valid UTF-8", expected_path.display()));
+    let normalize = |s: &str| s.replace("\r\n", "\n").replace("\\r\\n", "\\n");
+    assert_eq!(
+        normalize(body),
+        normalize(expected),
+        "\n--- expected ({}) ---\n{}\n--- actual ---\n{}",
+        expected_path.display(),
+        expected,
+        body
+    );
+}
+
+#[test]
+fn test_c_api_call_exec_program_with_pretty_error_format_and_compile_error() {
+    test_c_api_error(
+        "KclService.ExecProgram",
+        "exec-program-with-pretty-error-format-and-compile-error.json",
+        "exec-program-with-pretty-error-format-and-compile-error.response.error",
+    );
+}
+
+#[test]
+fn test_c_api_call_exec_program_with_short_error_format_and_compile_error() {
+    test_c_api_error(
+        "KclService.ExecProgram",
+        "exec-program-with-short-error-format-and-compile-error.json",
+        "exec-program-with-short-error-format-and-compile-error.response.error",
+    );
+}
+
+#[test]
+fn test_c_api_call_exec_program_with_arcanist_error_format_and_compile_error() {
+    test_c_api_error(
+        "KclService.ExecProgram",
+        "exec-program-with-arcanist-error-format-and-compile-error.json",
+        "exec-program-with-arcanist-error-format-and-compile-error.response.error",
+    );
+}
+
+#[test]
+fn test_c_api_call_exec_program_with_sarif_error_format_and_compile_error() {
+    test_c_api_error(
+        "KclService.ExecProgram",
+        "exec-program-with-sarif-error-format-and-compile-error.json",
+        "exec-program-with-sarif-error-format-and-compile-error.response.error",
+    );
+}
+
 #[test]
 fn test_c_api_call_exec_program_with_invalid_error_format() {
     test_c_api_panic::<ExecProgramArgs>(

--- a/crates/api/src/service/capi.rs
+++ b/crates/api/src/service/capi.rs
@@ -1,10 +1,37 @@
 use prost::Message;
 
 use crate::gpyrpc::*;
-use crate::service::service_impl::KclServiceImpl;
+use crate::service::service_impl::{
+    HasErrorFormat, KclServiceImpl, format_anyhow_error, resolve_error_format,
+};
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::slice;
+
+// All request arg types used by `call!` must impl `HasErrorFormat` so the
+// macro can ask them for an `error_format` override. Only
+// `ExecProgramArgs` actually carries the field today; every other arg
+// type uses the trait's default (which returns `""`, i.e. "no override,
+// render pretty"). Listing them here keeps the macro free of per-call
+// boilerplate and makes it obvious where a future `error_format` field
+// would need to be wired up.
+impl HasErrorFormat for PingArgs {}
+impl HasErrorFormat for GetVersionArgs {}
+impl HasErrorFormat for ParseFileArgs {}
+impl HasErrorFormat for ParseProgramArgs {}
+impl HasErrorFormat for LoadPackageArgs {}
+impl HasErrorFormat for ListVariablesArgs {}
+impl HasErrorFormat for OverrideFileArgs {}
+impl HasErrorFormat for GetSchemaTypeMappingArgs {}
+impl HasErrorFormat for FormatCodeArgs {}
+impl HasErrorFormat for FormatPathArgs {}
+impl HasErrorFormat for LintPathArgs {}
+impl HasErrorFormat for ValidateCodeArgs {}
+impl HasErrorFormat for LoadSettingsFilesArgs {}
+impl HasErrorFormat for RenameArgs {}
+impl HasErrorFormat for RenameCodeArgs {}
+impl HasErrorFormat for TestArgs {}
+impl HasErrorFormat for UpdateDependenciesArgs {}
 
 #[allow(non_camel_case_types)]
 type kcl_service = KclServiceImpl;
@@ -65,7 +92,17 @@ macro_rules! call {
             let res = serv_ref.$serv_name(&args);
             let result_byte = match res {
                 Ok(res) => res.encode_to_vec(),
-                Err(err) => format!("ERROR:{}", err.to_string()).into_bytes(),
+                Err(err) => {
+                    // Resolve the caller's requested diagnostic format
+                    // (falling back to pretty on any failure here so a
+                    // mis-formed `error_format` doesn't take down the
+                    // service call — `resolve_error_format` already
+                    // surfaces a hard panic for invalid values earlier in
+                    // the call chain, so this is just a safety net).
+                    let format = resolve_error_format(args.error_format())
+                        .unwrap_or(kcl_error::format::DiagnosticFormat::Pretty);
+                    format!("ERROR:{}", format_anyhow_error(&err, format)).into_bytes()
+                }
             };
             *$result_len = result_byte.len();
             CString::from_vec_unchecked(result_byte).into_raw()

--- a/crates/api/src/service/service_impl.rs
+++ b/crates/api/src/service/service_impl.rs
@@ -103,6 +103,57 @@ pub(crate) fn emit_machine_readable_error(
     Ok(())
 }
 
+/// Format `err` for the C API / language-binding return channel.
+///
+/// The native service returns its result-or-error to embedders as a single
+/// byte buffer (see `capi.rs`): on success the protobuf-encoded result, on
+/// failure an `ERROR:<msg>` payload. Before this helper existed the failure
+/// branch emitted `anyhow::Error::to_string()` directly, which is always the
+/// pretty renderer — making the `error_format` request of the caller (e.g.
+/// short / arcanist / sarif for machine consumption) silently ignored on the
+/// transport error path.
+///
+/// Now: when the caller asked for `Pretty` (the default) we keep the existing
+/// pretty rendering so the wire text is byte-compatible with the previous
+/// behaviour; for the other formats we wrap the pretty text in a
+/// `Diagnostic` and re-dispatch to `render_machine_readable_error`. If
+/// re-rendering itself fails (extremely rare — only if the renderer can't
+/// construct a `Diagnostic` for the given input) we fall back to the raw
+/// pretty text so the caller never sees an empty error message.
+pub(crate) fn format_anyhow_error(err: &anyhow::Error, format: DiagnosticFormat) -> String {
+    let pretty = err.to_string();
+    if format == DiagnosticFormat::Pretty {
+        return pretty;
+    }
+    match render_machine_readable_error(&pretty, format) {
+        Ok(rendered) if !rendered.is_empty() => rendered,
+        // Renderer returned empty (input was empty) or failed: never
+        // drop the message on the floor.
+        Ok(_) => pretty,
+        Err(_) => pretty,
+    }
+}
+
+/// Trait implemented by request argument types that carry an explicit
+/// `error_format` override. The C API uses this to pick the right
+/// rendering when a service call returns `Err`.
+///
+/// The default implementation returns `""`, which `resolve_error_format`
+/// interprets as "no override" — so existing arg types (PingArgs,
+/// GetVersionArgs, ...) keep their pre-existing pretty output without
+/// any per-type plumbing.
+pub trait HasErrorFormat {
+    fn error_format(&self) -> &str {
+        ""
+    }
+}
+
+impl HasErrorFormat for ExecProgramArgs {
+    fn error_format(&self) -> &str {
+        &self.error_format
+    }
+}
+
 /// Force the allocator to release freed memory back to the OS.
 ///
 /// On Linux **glibc** this calls `malloc_trim(0)`, which returns the top

--- a/crates/api/src/testdata/exec-program-with-arcanist-error-format-and-compile-error.json
+++ b/crates/api/src/testdata/exec-program-with-arcanist-error-format-and-compile-error.json
@@ -1,0 +1,10 @@
+{
+	"work_dir" : "./src/testdata",
+	"k_filename_list": [
+		"main.k"
+	],
+	"k_code_list": [
+		"a: int = \"str\"\n"
+	],
+	"error_format": "arcanist"
+}

--- a/crates/api/src/testdata/exec-program-with-arcanist-error-format-and-compile-error.response.error
+++ b/crates/api/src/testdata/exec-program-with-arcanist-error-format-and-compile-error.response.error
@@ -1,0 +1,11 @@
+[
+  {
+    "Char": 1,
+    "Code": "error[E3M38]",
+    "Description": "\nerror[E2G22]: TypeError\n---> File main.k:1:1: expected int, got str(str)\n\n",
+    "Line": 1,
+    "Name": "EvaluationError",
+    "OriginalText": "",
+    "Path": ""
+  }
+]

--- a/crates/api/src/testdata/exec-program-with-pretty-error-format-and-compile-error.json
+++ b/crates/api/src/testdata/exec-program-with-pretty-error-format-and-compile-error.json
@@ -1,0 +1,10 @@
+{
+	"work_dir" : "./src/testdata",
+	"k_filename_list": [
+		"main.k"
+	],
+	"k_code_list": [
+		"a: int = \"str\"\n"
+	],
+	"error_format": "pretty"
+}

--- a/crates/api/src/testdata/exec-program-with-pretty-error-format-and-compile-error.response.error
+++ b/crates/api/src/testdata/exec-program-with-pretty-error-format-and-compile-error.response.error
@@ -1,0 +1,4 @@
+
+error[E2G22]: TypeError
+---> File main.k:1:1: expected int, got str(str)
+

--- a/crates/api/src/testdata/exec-program-with-sarif-error-format-and-compile-error.json
+++ b/crates/api/src/testdata/exec-program-with-sarif-error-format-and-compile-error.json
@@ -1,0 +1,10 @@
+{
+	"work_dir" : "./src/testdata",
+	"k_filename_list": [
+		"main.k"
+	],
+	"k_code_list": [
+		"a: int = \"str\"\n"
+	],
+	"error_format": "sarif"
+}

--- a/crates/api/src/testdata/exec-program-with-sarif-error-format-and-compile-error.response.error
+++ b/crates/api/src/testdata/exec-program-with-sarif-error-format-and-compile-error.response.error
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "kcl",
+          "informationUri": "https://kcl-lang.io/",
+          "rules": [
+            {
+              "id": "E3M38",
+              "name": "EvaluationError",
+              "shortDescription": {
+                "text": "EvaluationError"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "E3M38",
+          "level": "error",
+          "message": {
+            "text": "\nerror[E2G22]: TypeError\n---> File main.k:1:1: expected int, got str(str)\n\n"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": ""
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/crates/api/src/testdata/exec-program-with-short-error-format-and-compile-error.json
+++ b/crates/api/src/testdata/exec-program-with-short-error-format-and-compile-error.json
@@ -1,0 +1,10 @@
+{
+	"work_dir" : "./src/testdata",
+	"k_filename_list": [
+		"main.k"
+	],
+	"k_code_list": [
+		"a: int = \"str\"\n"
+	],
+	"error_format": "short"
+}

--- a/crates/api/src/testdata/exec-program-with-short-error-format-and-compile-error.response.error
+++ b/crates/api/src/testdata/exec-program-with-short-error-format-and-compile-error.response.error
@@ -1,0 +1,5 @@
+error[E3M38]: EvaluationError - 
+error[E2G22]: TypeError
+---> File main.k:1:1: expected int, got str(str)
+
+


### PR DESCRIPTION
## Summary

- The C API returned service failures as `ERROR:<anyhow::Error::to_string()>`,
  which always rendered pretty regardless of the caller's requested
  `error_format`. Downstream SDKs (Go, Python, Node, etc.) had no way to get
  the machine-readable SARIF / short / arcanist variant on the
  transport-error path — they only ever saw it for runtime errors that
  came back as `Ok(ExecProgramResult)` with `err_message` populated, and
  even then the machine-readable copy lived only on stderr.
- Wire `error_format` through the `ERROR:` envelope so embedders see the
  same diagnostic format they asked for, even when the service itself
  fails (compile / type errors, missing files, etc.).
- Pretty output is byte-compatible with the pre-change behaviour, so
  callers relying on the existing text keep working.

## Design

- New `HasErrorFormat` trait in `service_impl.rs` with a default
  implementation returning `""` (no override). `ExecProgramArgs`
  overrides it with the proto field. The remaining 17 request arg types
  get empty `impl HasErrorFormat for $args {}` blocks in `capi.rs` so
  the `call!` macro can call `.error_format()` uniformly.
- New `format_anyhow_error(&anyhow::Error, DiagnosticFormat)` helper
  that returns the existing pretty text for the default format and wraps
  it in a `Diagnostic` for `render_machine_readable_error` on the other
  formats. Pretty output stays byte-compatible with the pre-change
  behaviour.
- `call!` macro resolves the format from the decoded args and routes
  `Err(...)` through `format_anyhow_error`. Invalid values still panic
  upstream via `resolve_error_format` (the C API path is just a safety
  net that falls back to pretty), so the
  `test_c_api_call_exec_program_with_invalid_error_format` panic
  fixture is unchanged.

## Test plan

- [x] `cargo test -p kcl-api --lib` — 48 passed, 0 failed (4 new tests
      exercising pretty / short / arcanist / sarif × type-error, each
      verified byte-for-byte against a `.response.error` fixture).
- [ ] Run full CI on this branch to confirm nothing else regresses
      (expected to be a no-op for non-`kcl-api` crates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)