### PR TITLE
fix(sema): collapse single-file import to its containing directory when they refer to the same files (fixes #1970)

### DIFF
--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -630,6 +630,92 @@ fn pkg_exists_in_path(path: &str, pkgpath: &str, load_cache: &mut ParseLoadCache
     exists
 }
 
+/// Compute the canonical [`pkgpath`] for [`pkgpath`] under [`pkgroot`].
+///
+/// KCL allows importing a single file via its dotted path (e.g. `import a.b.c`
+/// where the file is `a/b/c.k`). When the file also lives inside a directory
+/// that itself acts as a package (i.e. the directory `a/b/` contains other
+/// `.k` files), importing the file via either the directory form (`import
+/// a.b`) or the single-file form (`import a.b.c`) must yield the same
+/// canonical package. Otherwise the same [`SchemaType`] is registered twice
+/// under different pkgpaths and the type checker fails with confusing
+/// "expected X, got X" errors (see issue #1970).
+///
+/// This function returns the directory pkgpath when the single-file form
+/// would resolve to exactly the same file set as the directory form. That
+/// is the case only when the parent directory contains exactly one `.k`
+/// file: the file being imported. Otherwise the directory and single-file
+/// forms refer to genuinely different sets of files, and we leave the
+/// original pkgpath untouched to preserve the existing semantics.
+fn canonical_pkg_path(pkgroot: &str, pkgpath: &str) -> String {
+    let mut pathbuf = PathBuf::from(pkgroot);
+    for s in pkgpath.split('.') {
+        pathbuf.push(s);
+    }
+    // Already a directory package: nothing to canonicalize.
+    if pathbuf.is_dir() {
+        return pkgpath.to_string();
+    }
+    // Must resolve to a single .k file for the rewrite to apply.
+    let as_k_file = pathbuf.with_extension(KCL_FILE_EXTENSION);
+    if !as_k_file.is_file() {
+        return pkgpath.to_string();
+    }
+    // Walk up to the parent directory.
+    let parent = match pathbuf.parent() {
+        Some(p) => p,
+        None => return pkgpath.to_string(),
+    };
+    if !parent.is_dir() {
+        return pkgpath.to_string();
+    }
+    // The parent must itself be a package directory, i.e. it must contain
+    // at least one .k file. Otherwise the rewrite would unexpectedly pull
+    // in unrelated files.
+    //
+    // To preserve the original semantics where the directory form may load
+    // a strictly larger set of files than the single-file form, we only
+    // canonicalize when the parent contains *exactly* one .k file: the file
+    // being imported. In that case the two forms always reference the same
+    // file set, so collapsing the pkgpath is safe.
+    let mut k_count = 0usize;
+    let mut only_file_is_target = false;
+    if let Ok(entries) = std::fs::read_dir(parent) {
+        for entry in entries.flatten() {
+            let name = match entry.file_name().to_str() {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            if !name.ends_with(KCL_FILE_SUFFIX) || name.ends_with("_test.k") {
+                continue;
+            }
+            k_count += 1;
+            if entry.path() == as_k_file {
+                only_file_is_target = true;
+            }
+        }
+    }
+    if k_count == 0 || k_count > 1 || !only_file_is_target {
+        return pkgpath.to_string();
+    }
+    // Translate the parent path back to a dotted pkgpath relative to
+    // [`pkgroot`]. The result must be non-empty.
+    let rel = match parent.strip_prefix(pkgroot).ok() {
+        Some(p) => p,
+        None => return pkgpath.to_string(),
+    };
+    let mut canonical = rel
+        .to_string_lossy()
+        .replace(std::path::MAIN_SEPARATOR, ".");
+    while canonical.ends_with('.') {
+        canonical.pop();
+    }
+    if canonical.is_empty() || canonical == pkgpath {
+        return pkgpath.to_string();
+    }
+    canonical
+}
+
 /// Look for [`pkgpath`] in the current package's [`pkgroot`].
 /// If found, return to the [`PkgInfo`]， else return [`None`]
 ///
@@ -643,12 +729,18 @@ fn is_internal_pkg(
     load_cache: &mut ParseLoadCache,
 ) -> Result<Option<PkgInfo>> {
     if pkg_exists_in_path(pkg_root, pkg_path, load_cache) {
+        // Canonicalize the pkgpath so that `import a.b` (directory) and
+        // `import a.b.c` (single file) refer to the same package when both
+        // forms resolve to overlapping files. Without this, the same schema
+        // would be registered under two different pkgpaths, breaking
+        // assignability checks (issue #1970).
+        let canonical_pkg_path = canonical_pkg_path(pkg_root, pkg_path);
         let fullpath = if pkg_name == kcl_ast::MAIN_PKG {
-            pkg_path.to_string()
+            canonical_pkg_path.clone()
         } else {
-            format!("{}.{}", pkg_name, pkg_path)
+            format!("{}.{}", pkg_name, canonical_pkg_path)
         };
-        let k_files = get_pkg_kfile_list(pkg_root, pkg_path, load_cache)?;
+        let k_files = get_pkg_kfile_list(pkg_root, &canonical_pkg_path, load_cache)?;
         Ok(Some(PkgInfo::new(
             pkg_name.to_string(),
             pkg_root.to_string(),

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -881,3 +881,59 @@ fn parse_all_file_under_path() {
 
     assert_eq!(res.paths.len(), 1);
 }
+
+#[test]
+#[cfg(not(windows))]
+fn test_canonical_pkg_path() {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn fresh_tmp(label: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("kcl-canonical-pkg-path-{label}-{nanos}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    // Layout 1: parent directory contains exactly one .k file (the
+    // single-file target). `pkg.path` resolves to that file and the
+    // canonicalization should rewrite the pkgpath to the parent.
+    let single = fresh_tmp("single");
+    let parent = single.join("pkg");
+    fs::create_dir_all(&parent).unwrap();
+    fs::write(parent.join("path.k"), "schema S: x: int\n").unwrap();
+    assert_eq!(
+        canonical_pkg_path(single.to_str().unwrap(), "pkg.path"),
+        "pkg"
+    );
+
+    // Layout 2: parent directory contains multiple .k files. The directory
+    // and single-file forms refer to different file sets, so we must leave
+    // the pkgpath untouched to preserve existing semantics.
+    let multi = fresh_tmp("multi");
+    let multi_parent = multi.join("pkg");
+    fs::create_dir_all(&multi_parent).unwrap();
+    fs::write(multi_parent.join("path.k"), "").unwrap();
+    fs::write(multi_parent.join("other.k"), "").unwrap();
+    assert_eq!(
+        canonical_pkg_path(multi.to_str().unwrap(), "pkg.path"),
+        "pkg.path"
+    );
+
+    // Layout 3: pkgpath resolves to a directory. Nothing to canonicalize.
+    let dir = fresh_tmp("dir");
+    let dir_pkg = dir.join("pkg");
+    fs::create_dir_all(&dir_pkg).unwrap();
+    fs::write(dir_pkg.join("foo.k"), "").unwrap();
+    assert_eq!(canonical_pkg_path(dir.to_str().unwrap(), "pkg"), "pkg");
+
+    // Layout 4: pkgpath does not resolve to anything. Returned unchanged.
+    let missing = fresh_tmp("missing");
+    assert_eq!(
+        canonical_pkg_path(missing.to_str().unwrap(), "does.not.exist"),
+        "does.not.exist"
+    );
+}

--- a/tests/grammar/import/import_pkg_vs_file_same_target/configs/other/type.k
+++ b/tests/grammar/import/import_pkg_vs_file_same_target/configs/other/type.k
@@ -1,0 +1,2 @@
+schema OtherType:
+    name: str

--- a/tests/grammar/import/import_pkg_vs_file_same_target/kcl.mod
+++ b/tests/grammar/import/import_pkg_vs_file_same_target/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "repro"
+edition = "v0.12.0"
+version = "0.0.1"

--- a/tests/grammar/import/import_pkg_vs_file_same_target/main.k
+++ b/tests/grammar/import/import_pkg_vs_file_same_target/main.k
@@ -1,0 +1,6 @@
+import configs.other
+import types.mytype
+
+output = mytype.MyType {
+    field1 = other.OtherType {name = "x"}
+}

--- a/tests/grammar/import/import_pkg_vs_file_same_target/stdout.golden
+++ b/tests/grammar/import/import_pkg_vs_file_same_target/stdout.golden
@@ -1,0 +1,3 @@
+output:
+  field1:
+    name: x

--- a/tests/grammar/import/import_pkg_vs_file_same_target/types/mytype.k
+++ b/tests/grammar/import/import_pkg_vs_file_same_target/types/mytype.k
@@ -1,0 +1,4 @@
+import configs.other.type as othertype
+
+schema MyType:
+    field1: othertype.OtherType

--- a/tests/grammar/schema/type/type_fail_20/stderr.golden
+++ b/tests/grammar/schema/type/type_fail_20/stderr.golden
@@ -2,5 +2,5 @@ error[E2G22]: TypeError
  --> ${CWD}/main.k:6:12
   |
 6 |     info0: info.inf
-  |            ^ attribute 'inf' not found in 'module 'pkg.info''
+  |            ^ attribute 'inf' not found in 'module 'pkg''
   |


### PR DESCRIPTION
## Summary
- Fix #1970: importing the same file via both its directory package (e.g. `import configs.other`) and its single-file path (e.g. `import configs.other.type`) previously registered the schema under two different pkgpaths, producing confusing `expected X, got X` errors during assignability checks.
- The fix adds a `canonical_pkg_path` helper used by `is_internal_pkg` to collapse the pkgpath of a single-file import to its containing directory whenever the two forms resolve to exactly the same file set (parent directory contains exactly one `.k` file: the file being imported). All other layouts preserve the existing semantics.

## Root cause
When `main.k` (or any importing file) contains both `import configs.other` and `import configs.other.type as othertype` (where `configs/other/type.k` is the only file in `configs/other/`), the parser's package resolver previously returned two distinct `PkgInfo`s with different pkgpaths:
- `configs.other` -> `[configs/other/type.k]`
- `configs.other.type` -> `[configs/other/type.k]`

`parse_program` then groups files by `pkg_path` into `program.pkgs`, so the same on-disk file ended up under two different package keys. The semantic analyzer therefore created two `SchemaType` instances for `OtherType`, one with `pkgpath = "configs.other"` and one with `pkgpath = "configs.other.type"`. `is_sub_schema_of` compares `full_ty_str() = "{pkgpath}.{name}"`, so the two schemas failed to be considered the same type.

## Test plan
- [x] New grammar test `tests/grammar/import/import_pkg_vs_file_same_target/` reproduces the exact scenario from the issue end-to-end.
- [x] Unit test `tests::test_canonical_pkg_path` covers the four cases of the helper (single file in parent, multi file in parent, directory, missing).
- [x] Existing grammar test `tests/grammar/schema/type/type_fail_20/` golden updated to reflect the now-canonical (parent) module name; the assertion still fires for the same reason.
- [x] All 1596 grammar tests pass.
- [x] All 509 parser unit tests pass; sema/loader/runner/driver/cmd/config tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)