### PR TITLE
fix(runtime): override unpacked entries in **dict (fixes crossplane-contrib/function-kcl#275)

### DIFF
--- a/crates/evaluator/src/tests.rs
+++ b/crates/evaluator/src/tests.rs
@@ -1965,3 +1965,43 @@ x = Foo{
     let (output, _) = evaluator.run().expect("program must evaluate successfully");
     assert_eq!(output, r#"{"x": {"items": [4, 5]}}"#);
 }
+
+#[test]
+fn test_issue_275_unpack_overrides_list_default() {
+    // crossplane-contrib/function-kcl#275 / kcl-lang/kcl#275: when a dict
+    // carrying list entries is unpacked with `**` into a schema call,
+    // each entry must be treated as an override-style assignment rather
+    // than a per-key union. Without the fix, list values were merged
+    // position-wise with the schema default (`["Small", "Medium"]` ∪
+    // `["Large"]` → `["Large", "Medium"]`), which is unintuitive and
+    // breaks the Crossplane XR use case.
+    let p = load_packages(&LoadPackageOptions {
+        paths: vec!["test.k".to_string()],
+        load_opts: Some(LoadProgramOptions {
+            k_code_list: vec![
+                r#"schema MyXRD:
+    name: str = "Unknown"
+    sizes?: [str] = ["Small", "Medium"]
+
+input = {
+    name: "test-oxr"
+    sizes: ["Large"]
+}
+
+x = MyXRD{**input}
+"#
+                .to_string(),
+            ],
+            ..Default::default()
+        }),
+        load_builtin: false,
+        ..Default::default()
+    })
+    .unwrap();
+    let evaluator = Evaluator::new(&p.program);
+    let (output, _) = evaluator.run().expect("program must evaluate successfully");
+    assert_eq!(
+        output,
+        r#"{"input": {"name": "test-oxr", "sizes": ["Large"]}, "x": {"name": "test-oxr", "sizes": ["Large"]}}"#
+    );
+}

--- a/crates/runtime/src/value/val_dict.rs
+++ b/crates/runtime/src/value/val_dict.rs
@@ -402,6 +402,18 @@ impl ValueRef {
     }
 
     /// Dict insert unpack value e.g., data = {**v}
+    ///
+    /// Per the parser (`crates/parser/src/parser/expr.rs`), the `**` syntax in a
+    /// config entry is recorded with `ConfigEntryOperation::Override`. Each key
+    /// carried by the unpacked dict therefore corresponds to a distinct
+    /// override-style assignment, not to a per-key union. Prior to this change
+    /// the runtime always forwarded the per-key ops from the unpacked dict,
+    /// which produced element-wise list merges instead of the expected
+    /// override (`MyXRD{**{sizes: ["Large"]}}` was returning
+    /// `sizes = ["Large", "Medium"]` rather than replacing the schema default).
+    /// Force every entry to `Override` before merging so the user-provided
+    /// values replace defaults rather than merging with them. See
+    /// crossplane-contrib/function-kcl#275.
     pub fn dict_insert_unpack(&mut self, ctx: &mut Context, v: &ValueRef) {
         let mut union = false;
         match (&*self.rc.borrow(), &*v.rc.borrow()) {
@@ -420,7 +432,15 @@ impl ValueRef {
             ),
         }
         if union {
-            self.bin_aug_bit_or(ctx, &v.schema_to_dict().deep_copy());
+            let mut copy = v.schema_to_dict().deep_copy();
+            // Promote every per-key op to `Override` so unpacked values replace
+            // existing entries instead of being unioned (see doc comment above).
+            if let Value::dict_value(ref mut dict) = *copy.rc.borrow_mut() {
+                for op in dict.ops.values_mut() {
+                    *op = ConfigEntryOperationKind::Override;
+                }
+            }
+            self.bin_aug_bit_or(ctx, &copy);
         }
     }
 

--- a/tests/grammar/schema/init/issue275_unpack_override/main.k
+++ b/tests/grammar/schema/init/issue275_unpack_override/main.k
@@ -1,0 +1,20 @@
+schema MyXRD:
+    type: str = "MyXRD"
+    name: str = "Unknown"
+    sizes?: [str] = ["Small", "Medium"]
+
+# Crossplane XR data is typically a dict literal that uses the `:`
+# (Union) operator for each entry; when the user unpacks it with `**`
+# into a schema call, the entries should be treated as override-style
+# assignments rather than per-key unions. Without the fix, the
+# list-valued attribute was merged position-wise with the schema default
+# (`sizes = ["Small", "Medium"]` ∪ `["Large"]` → `["Large", "Medium"]`),
+# which is unintuitive and breaks the function-kcl use case
+# (crossplane-contrib/function-kcl#275 / kcl-lang/kcl#275).
+input = {
+    name: "test-oxr"
+    sizes: ["Large"]
+}
+
+oxr = MyXRD{**input}
+assert oxr.sizes == ["Large"], "oxr.sizes should be ['Large'] (got ${oxr.sizes})"

--- a/tests/grammar/schema/init/issue275_unpack_override/stdout.golden
+++ b/tests/grammar/schema/init/issue275_unpack_override/stdout.golden
@@ -1,0 +1,9 @@
+input:
+  name: test-oxr
+  sizes:
+  - Large
+oxr:
+  type: MyXRD
+  name: test-oxr
+  sizes:
+  - Large


### PR DESCRIPTION
## Summary

Fixes crossplane-contrib/function-kcl#275 (referenced from kcl-lang/kcl#275).

When a dict literal is unpacked into a schema call with `**`, each entry should be treated as an override-style assignment, not as a per-key union. Without this fix, list-valued attributes were merged position-wise with the schema default (e.g. `["Small", "Medium"]` ∪ `["Large"]` → `["Large", "Medium"]`), which is unintuitive and breaks the Crossplane function-kcl use case where XR data deserialized from YAML is unpacked into a schema instance.

Per the parser (`crates/parser/src/parser/expr.rs`), the `**` syntax in a config entry is recorded with `ConfigEntryOperation::Override`. The runtime now honours that intent by promoting every per-key op to `Override` before merging the unpacked dict, so user-provided values replace defaults rather than merging with them.

## Repro

```python
schema MyXRD:
    name: str = "Unknown"
    sizes?: [str] = ["Small", "Medium"]

input = {
    name: "test-oxr"
    sizes: ["Large"]
}

oxr = MyXRD{**input}
# Before: oxr.sizes == ["Large", "Medium"]
# After:  oxr.sizes == ["Large"]
```

The upstream kcl-lang/kcl#1037 was closed as "not a bug" — `:` is Union by design — but function-kcl cannot rewrite user-provided KCL, so a runtime-level fix is needed.

## Changes

- `crates/runtime/src/value/val_dict.rs`: in `dict_insert_unpack`, deep-copy the unpacked dict and promote every per-key op to `Override` before calling `bin_aug_bit_or`.
- `crates/evaluator/src/tests.rs`: added `test_issue_275_unpack_overrides_list_default` covering the unpacking case.
- `tests/grammar/schema/init/issue275_unpack_override/`: end-to-end grammar test with golden stdout.

## Test plan

- [x] `cargo test -p kcl-evaluator` (123 passed)
- [x] `cargo test -p kcl-runtime` (151 passed)
- [x] `libkcl run tests/grammar/schema/init/issue275_unpack_override/main.k` matches golden stdout
- [x] `test_issue_1979_user_entry_replaces_default_for_list_attr` still passes