### PR TITLE
fix(evaluator): honour child schema attribute overrides (fixes #1707)

### DIFF
--- a/crates/evaluator/src/node.rs
+++ b/crates/evaluator/src/node.rs
@@ -525,6 +525,18 @@ impl<'ctx> TypedResultWalker<'ctx> for Evaluator<'ctx> {
         self.clear_local_vars();
         let name = schema_attr.name.node.as_str();
         self.add_target_var(name);
+        // If this walk happens while processing the body of a parent schema
+        // on behalf of a child (`is_sub_schema == false`), the child has
+        // already pre-populated `attr_map` in `schema_body` with the
+        // most-derived type for any attribute it overrides. We must keep
+        // that type (it drives recursive conversion in `value_union`), but
+        // we still need to apply the parent's default value when the child
+        // redeclares the attribute without one and the user did not supply
+        // a value. See kcl-lang/kcl#1707.
+        let attr_already_claimed = self
+            .get_schema_eval_context()
+            .map(|c| !c.borrow().is_sub_schema && c.borrow().value.attr_map_get(name).is_some())
+            .unwrap_or(false);
         for decorator in &schema_attr.decorators {
             self.walk_decorator_with_name(&decorator.node, Some(name), false)
                 .expect(kcl_error::INTERNAL_ERROR_MSG);
@@ -532,7 +544,9 @@ impl<'ctx> TypedResultWalker<'ctx> for Evaluator<'ctx> {
         let (mut schema_value, config_value, _) = self
             .get_schema_or_rule_config_info()
             .expect(kcl_error::INTERNAL_ERROR_MSG);
-        schema_value.update_attr_map(name, &schema_attr.ty.node.to_string());
+        if !attr_already_claimed {
+            schema_value.update_attr_map(name, &schema_attr.ty.node.to_string());
+        }
         if let Some(entry) = config_value.dict_get_entry(name) {
             let is_override_attr = {
                 let is_override_op = matches!(

--- a/crates/evaluator/src/schema.rs
+++ b/crates/evaluator/src/schema.rs
@@ -584,6 +584,26 @@ pub(crate) fn schema_body(
     kwargs: &ValueRef,
 ) -> ValueRef {
     init_lazy_scope(s, &mut ctx.borrow_mut());
+    // Pre-populate `attr_map` with this schema's attribute types *before*
+    // calling the parent's schema body. The parent schema's body walks the
+    // shared dict via `walk_schema_attr` and calls `value_union` for any
+    // user-provided entries; that `value_union` reads the type from
+    // `attr_map` and recursively converts the value. Without this
+    // pre-population, `attr_map` only reflects the parent's (base) types,
+    // so a child that overrides an attribute with a more-specific schema
+    // (e.g. extending a `[...str]: BaseX` with `[...str]: NewX`) would
+    // trigger recursive conversion against `BaseX`, which can reject
+    // attributes only present in the override (`NewX`). See
+    // kcl-lang/kcl#1707.
+    if ctx.borrow().node.parent_name.is_some() {
+        let ctx_ref = ctx.borrow();
+        let mut schema_value = ctx_ref.value.clone();
+        for stmt in &ctx_ref.node.body {
+            if let ast::Stmt::SchemaAttr(sa) = &stmt.node {
+                schema_value.update_attr_map(&sa.name.node, &sa.ty.node.to_string());
+            }
+        }
+    }
     // Schema self value or parent schema value;
     let mut schema_ctx_value = if let Some(parent_name) = &ctx.borrow().node.parent_name {
         let base_constructor_func = s.load_global_value(

--- a/tests/grammar/schema/inherit/inherit_index_signature_override_0/main.k
+++ b/tests/grammar/schema/inherit/inherit_index_signature_override_0/main.k
@@ -1,0 +1,42 @@
+schema ContainerInputs:
+    maxReplicas?: int = 3
+
+schema DeploymentInputs:
+    [...str]: ContainerInputs
+
+schema DeploymentCollectionInputs:
+    [...str]: DeploymentInputs
+
+schema NewContainerInputs(ContainerInputs):
+    minReplicas?: int = 2
+
+schema NewDeploymentInputs(DeploymentInputs):
+    [...str]: NewContainerInputs
+
+schema NewDeploymentCollectionInputs(DeploymentCollectionInputs):
+    [...str]: NewDeploymentInputs
+
+schema Inputs:
+    vdeployments: DeploymentCollectionInputs
+
+schema NewInputs(Inputs):
+    vdeployments: NewDeploymentCollectionInputs
+
+a = Inputs {
+    vdeployments: {
+        deploy_a: {
+            container_a: {
+                maxReplicas: 4
+            }
+        }
+    }
+}
+b = NewInputs {
+    vdeployments: {
+        deploy_b: {
+            container_b: {
+              minReplicas: 2
+            }
+        }
+    }
+}

--- a/tests/grammar/schema/inherit/inherit_index_signature_override_0/stdout.golden
+++ b/tests/grammar/schema/inherit/inherit_index_signature_override_0/stdout.golden
@@ -1,0 +1,11 @@
+a:
+  vdeployments:
+    deploy_a:
+      container_a:
+        maxReplicas: 4
+b:
+  vdeployments:
+    deploy_b:
+      container_b:
+        maxReplicas: 3
+        minReplicas: 2


### PR DESCRIPTION
closes #1707

## Summary

When a child schema overrides an attribute with a more-specific schema (e.g. `NewInputs { vdeployments: NewDeploymentCollectionInputs }` over `Inputs { vdeployments: DeploymentCollectionInputs }`), runtime type inference against nested index signatures (`[...str]: ContainerInputs` → `NewContainerInputs`) was using the *base* types, so attributes only present in the override (`minReplicas`) triggered `Schema ContainerInputs does not contain attribute minReplicas`.

## Root cause

`schema_body` invoked the parent schema's body before walking the child's body. The parent's `walk_schema_attr` therefore wrote its base type into the shared `attr_map` and then called `value_union` against the user-provided value. `value_union` reads `attr_map` and runs `convert_collection_value` recursively — but the recursion always uses the **base** schema's index-signature value types (`DeploymentInputs` → `ContainerInputs`), so it never sees the override (`NewDeploymentInputs` → `NewContainerInputs`). The child's body never got the chance to overwrite `attr_map` because the conversion error fired first.

## Fix

- Pre-populate `attr_map` with the child schema's declared attribute types *before* invoking the parent's body (`schema_body`).
- In `walk_schema_attr`, skip `update_attr_map` when walking a parent schema's body on behalf of a child (`is_sub_schema == false`) and the attribute is already claimed — this preserves the override type for the `value_union` call below, while still applying the parent's default value (when the child redeclares without one).

## Test plan

- New regression test: `tests/grammar/schema/inherit/inherit_index_signature_override_0/` reproduces the exact scenario from the issue.
- Existing test suite: all 1601 grammar tests, 128 runtime tests, 122 evaluator unit tests, 151 runtime unit tests, and the sema test suite pass.