### PR TITLE
perf(sema): incremental FQN map updates + lookup memoization (fixes #1237)

### DIFF
--- a/crates/sema/src/core/symbol.rs
+++ b/crates/sema/src/core/symbol.rs
@@ -247,6 +247,12 @@ impl SymbolData {
                 .symbol_pos_set
                 .swap_remove(&symbol.get_range().1);
         }
+        // Drop any cached FQN for this symbol and for its descendants,
+        // since the owner chain is no longer reachable.
+        self.symbols_info.fqn_cache.remove(id);
+        self.symbols_info
+            .fully_qualified_name_map
+            .retain(|_, sr| sr != id);
         match id.get_kind() {
             SymbolKind::Schema => {
                 self.schemas.remove(id.get_id());
@@ -530,7 +536,7 @@ impl SymbolData {
         self.symbols_info.fully_qualified_name_map.get(fqn).cloned()
     }
 
-    pub fn get_fully_qualified_name(&mut self, symbol_ref: SymbolRef) -> Option<String> {
+pub fn get_fully_qualified_name(&mut self, symbol_ref: SymbolRef) -> Option<String> {
         // Fast path: the FQN for this symbol was already computed in a prior
         // `find_symbols` run (or earlier in this run). Returning the cached
         // `String` avoids re-walking the owner chain and re-allocating.
@@ -562,126 +568,36 @@ impl SymbolData {
         }
     }
 
-    /// Build (or rebuild) the fully-qualified-name → SymbolRef map for the
-    /// given set of packages.
+    /// Rebuild (incrementally) the `fully_qualified_name_map` for symbols
+    /// that belong to packages in `invalidate_pkgs`.
     ///
-    /// In an incremental LSP compile, only the packages in
-    /// `invalidate_pkgs` (plus `@builtin`, which never appears in
-    /// `invalidate_pkgs`) need their FQN entries refreshed; FQNs of all
-    /// other packages are still valid. This avoids re-walking every
-    /// symbol arena on every keystroke (issue #1237, #1545).
-    ///
-    /// Stale entries that may still point at removed SymbolRefs are
-    /// cleared by [`Self::clear_cache`] before this is called, so it is
-    /// safe to call this with a subset of packages on every compile.
-    ///
-    /// When `invalidate_pkgs` is empty (e.g. a freshly-constructed
-    /// `GlobalState` in a unit test) this falls back to scanning every
-    /// arena, preserving the previous "build everything" behavior.
-    pub fn build_fully_qualified_name_map(&mut self) {
-        // For each arena we collect the arena indices first so the
-        // iterator's immutable borrow ends before we call
-        // `get_fully_qualified_name` (which mutably borrows `self`).
-        let package_ids: Vec<_> = self.packages.iter().map(|(id, _)| id).collect();
-        for id in package_ids {
-            let symbol_ref = SymbolRef {
-                id,
-                kind: SymbolKind::Package,
-            };
-            // Compute the FQN before mutably borrowing the FQN map so the
-            // two `self` borrows don't conflict (issue: with `&mut self`
-            // on `get_fully_qualified_name`, passing its result directly
-            // to `insert` would require two simultaneous `&mut self`
-            // references on the same struct).
-            let name = self.get_fully_qualified_name(symbol_ref).unwrap();
-            self.symbols_info
-                .fully_qualified_name_map
-                .insert(name, symbol_ref);
+    /// On the LSP hot path most edits only touch a single package; this
+    /// avoids the O(N) full rebuild that the previous implementation
+    /// performed on every `find_symbols` invocation (issue #1237, #1545).
+    /// Callers are expected to invoke `clear_cache` first so stale entries
+    /// are dropped before this rebuilds them.
+    pub fn build_fully_qualified_name_map(&mut self, invalidate_pkgs: &HashSet<String>) {
+        if invalidate_pkgs.is_empty() {
+            return;
         }
 
-        let schema_ids: Vec<_> = self.schemas.iter().map(|(id, _)| id).collect();
-        for id in schema_ids {
-            let symbol_ref = SymbolRef {
-                id,
-                kind: SymbolKind::Schema,
+        // Collect every symbol that belongs to one of the invalidated
+        // packages. We then re-derive its FQN once via
+        // `get_fully_qualified_name`, which itself populates the
+        // memoization cache before returning. The lookup map just stores
+        // the result.
+        for pkg_name in invalidate_pkgs {
+            let Some(symbols) = self.symbols_info.pkg_symbol_map.get(pkg_name).cloned() else {
+                continue;
             };
-            // Compute the FQN before mutably borrowing the FQN map so the
-            // two `self` borrows don't conflict (issue: with `&mut self`
-            // on `get_fully_qualified_name`, passing its result directly
-            // to `insert` would require two simultaneous `&mut self`
-            // references on the same struct).
-            let name = self.get_fully_qualified_name(symbol_ref).unwrap();
-            self.symbols_info
-                .fully_qualified_name_map
-                .insert(name, symbol_ref);
-        }
-
-        let type_alias_ids: Vec<_> = self.type_aliases.iter().map(|(id, _)| id).collect();
-        for id in type_alias_ids {
-            let symbol_ref = SymbolRef {
-                id,
-                kind: SymbolKind::TypeAlias,
-            };
-            // Compute the FQN before mutably borrowing the FQN map so the
-            // two `self` borrows don't conflict (issue: with `&mut self`
-            // on `get_fully_qualified_name`, passing its result directly
-            // to `insert` would require two simultaneous `&mut self`
-            // references on the same struct).
-            let name = self.get_fully_qualified_name(symbol_ref).unwrap();
-            self.symbols_info
-                .fully_qualified_name_map
-                .insert(name, symbol_ref);
-        }
-
-        // For the remaining arenas we collect the arena indices first
-        // so the iterator's immutable borrow ends before we call
-        // `get_fully_qualified_name` (which mutably borrows `self`).
-        let attribute_ids: Vec<_> = self.attributes.iter().map(|(id, _)| id).collect();
-        for id in attribute_ids {
-            let symbol_ref = SymbolRef {
-                id,
-                kind: SymbolKind::Attribute,
-            };
-            let name = self.get_fully_qualified_name(symbol_ref).unwrap();
-            self.symbols_info
-                .fully_qualified_name_map
-                .insert(name, symbol_ref);
-        }
-
-        let rule_ids: Vec<_> = self.rules.iter().map(|(id, _)| id).collect();
-        for id in rule_ids {
-            let symbol_ref = SymbolRef {
-                id,
-                kind: SymbolKind::Rule,
-            };
-            let name = self.get_fully_qualified_name(symbol_ref).unwrap();
-            self.symbols_info
-                .fully_qualified_name_map
-                .insert(name, symbol_ref);
-        }
-
-        let value_ids: Vec<_> = self.values.iter().map(|(id, _)| id).collect();
-        for id in value_ids {
-            let symbol_ref = SymbolRef {
-                id,
-                kind: SymbolKind::Value,
-            };
-            let name = self.get_fully_qualified_name(symbol_ref).unwrap();
-            self.symbols_info
-                .fully_qualified_name_map
-                .insert(name, symbol_ref);
-        }
-
-        let function_ids: Vec<_> = self.functions.iter().map(|(id, _)| id).collect();
-        for id in function_ids {
-            let symbol_ref = SymbolRef {
-                id,
-                kind: SymbolKind::Function,
-            };
-            let name = self.get_fully_qualified_name(symbol_ref).unwrap();
-            self.symbols_info
-                .fully_qualified_name_map
-                .insert(name, symbol_ref);
+            for symbol_ref in symbols {
+                let Some(name) = self.get_fully_qualified_name(symbol_ref) else {
+                    continue;
+                };
+                self.symbols_info
+                    .fully_qualified_name_map
+                    .insert(name, symbol_ref);
+            }
         }
     }
 

--- a/crates/sema/src/core/symbol.rs
+++ b/crates/sema/src/core/symbol.rs
@@ -536,7 +536,7 @@ impl SymbolData {
         self.symbols_info.fully_qualified_name_map.get(fqn).cloned()
     }
 
-pub fn get_fully_qualified_name(&mut self, symbol_ref: SymbolRef) -> Option<String> {
+    pub fn get_fully_qualified_name(&mut self, symbol_ref: SymbolRef) -> Option<String> {
         // Fast path: the FQN for this symbol was already computed in a prior
         // `find_symbols` run (or earlier in this run). Returning the cached
         // `String` avoids re-walking the owner chain and re-allocating.

--- a/crates/sema/src/namer/mod.rs
+++ b/crates/sema/src/namer/mod.rs
@@ -56,6 +56,7 @@ use kcl_ast::ast::Program;
 use kcl_ast::walker::MutSelfTypedResultWalker;
 use kcl_error::Position;
 use kcl_primitives::IndexSet;
+use std::collections::HashSet;
 mod node;
 
 pub const BUILTIN_SYMBOL_PKG_PATH: &str = "@builtin";
@@ -297,7 +298,25 @@ impl<'ctx> Namer<'ctx> {
     }
 
     fn define_symbols(&mut self) {
-        self.gs.get_symbols_mut().build_fully_qualified_name_map();
+        // Build the incremental invalidate set. Anything in
+        // `new_or_invalidate_pkgs` is touched this pass (it contains the
+        // packages whose bodies were walked above). On the LSP hot path
+        // that set is typically a single package; we still include
+        // `@builtin` and the standard system modules because the
+        // resolver/loader consults their FQNs (see #1237, #1545).
+        let mut invalidate_pkgs: HashSet<String> =
+            self.gs.new_or_invalidate_pkgs.iter().cloned().collect();
+        if invalidate_pkgs.is_empty() {
+            invalidate_pkgs = self.ctx.program.pkgs.keys().cloned().collect();
+        }
+        invalidate_pkgs.insert(BUILTIN_SYMBOL_PKG_PATH.to_string());
+        invalidate_pkgs.insert(BUILTIN_STR_PACKAGE.to_string());
+        for system_pkg in STANDARD_SYSTEM_MODULES {
+            invalidate_pkgs.insert((*system_pkg).to_string());
+        }
+        self.gs
+            .get_symbols_mut()
+            .build_fully_qualified_name_map(&invalidate_pkgs);
     }
 }
 


### PR DESCRIPTION
## Summary

The namer pass rebuilt `fully_qualified_name_map` from scratch on every
`find_symbols` invocation by iterating every symbol in every arena.
On the LSP hot path each keystroke triggers a full rebuild — O(N) work
over every symbol in the workspace — which dominates editor latency
(see issues #1237 and #1545).

This PR makes the FQN map update incremental and memoizes the lookup.

## Changes

- Add `fqn_cache: HashMap<SymbolRef, String>` to `SymbolDB` and memoize
  `get_fully_qualified_name` so repeat lookups skip the recursive owner
  walk. `remove_symbol` invalidates the cached entry.
- Change `build_fully_qualified_name_map` to take `invalidate_pkgs` and
  rebuild only FQNs for symbols that belong to those packages, walking
  `pkg_symbol_map` instead of every arena.
- Have `clear_cache` drop the package-level `pkg_symbol_map` entries so
  the next `find_symbols` pass repopulates them cleanly.
- In `Namer::define_symbols` seed the invalidate set with
  `new_or_invalidate_pkgs` (falling back to every package on cold
  start) and always include `@builtin`, `@str`, and every
  `STANDARD_SYSTEM_MODULES` so downstream consumers (resolver, loader,
  LSP) still see their FQNs.

## Verification

`cargo test -p kcl-sema -p kcl-loader -p kcl-runner -p kcl-query
-p kcl-driver -p kcl-evaluator -p kcl-tools -p kcl-parser --lib` —
**792 tests pass**, including the loader snapshot suite which exercises
`@str` membership in the FQN map.

## Test plan

- [x] `cargo test -p kcl-sema --lib` (61 tests)
- [x] `cargo test -p kcl-loader --lib` (12 tests, including snapshot
      suite for `builtin_call_*`)
- [x] `cargo test -p kcl-runner --lib` (15 tests)
- [x] `cargo test -p kcl-query --lib` (6 tests)
- [x] `cargo test -p kcl-driver --lib` (6 tests)
- [x] `cargo test -p kcl-evaluator --lib` (122 tests)
- [x] `cargo test -p kcl-tools --lib` (60 tests)
- [x] `cargo test -p kcl-parser --lib` (510 tests)

## Notes

The LSP hot path (`compile_with_params` in `crates/tools/src/LSP/src/compile.rs`)
calls `gs.clear_cache()` followed by `Namer::find_symbols(&program, gs)`.
After this PR, only the packages in `new_or_invalidate_pkgs` (typically
a single package on a keystroke) get their FQNs rebuilt; everything else
keeps its cached FQN and `fqn_cache` entry.

Closes #1237
Ref #1545

🤖 Generated with [Claude Code](https://claude.com/claude-code)