### PR TITLE
feat(lsp): run KCL unit tests by clicking a CodeLens (fixes #1482)

### DIFF
--- a/crates/tools/src/LSP/src/capabilities.rs
+++ b/crates/tools/src/LSP/src/capabilities.rs
@@ -1,6 +1,6 @@
 use lsp_types::{
     ClientCapabilities, CodeActionKind, CodeActionOptions, CodeActionProviderCapability,
-    CompletionOptions, HoverProviderCapability, OneOf, SemanticTokensFullOptions,
+    CodeLensOptions, CompletionOptions, HoverProviderCapability, OneOf, SemanticTokensFullOptions,
     SemanticTokensLegend, SemanticTokensOptions, ServerCapabilities, SignatureHelpOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, WorkDoneProgressOptions,
 };
@@ -69,6 +69,9 @@ pub fn server_capabilities(client_caps: &ClientCapabilities) -> ServerCapabiliti
             work_done_progress_options: WorkDoneProgressOptions {
                 work_done_progress: None,
             },
+        }),
+        code_lens_provider: Some(CodeLensOptions {
+            resolve_provider: Some(false),
         }),
         ..Default::default()
     }

--- a/crates/tools/src/LSP/src/code_lens.rs
+++ b/crates/tools/src/LSP/src/code_lens.rs
@@ -1,0 +1,136 @@
+use kcl_ast::ast;
+use kcl_parser::{ParseSessionRef, parse_file_with_global_session};
+use kcl_tools::testing::{TEST_FILE_SUFFIX, TEST_SUITE_PREFIX};
+use lsp_types::{CodeLens, Command, Position, Range};
+use serde_json::json;
+use std::path::Path;
+
+/// The client-side command a test lens invokes. Clients that want the
+/// "run test" action must register a handler for it, e.g. `vscode-kcl`.
+pub const RUN_TEST_COMMAND: &str = "kcl.runTest";
+
+/// Returns a `run test` lens for every test case in a KCL test suite file.
+///
+/// Test suites are `*_test.k` files and test cases are top level
+/// `test_xxx = lambda { ... }` assignments, matching the discovery rules of
+/// the `kcl test` tool in [`kcl_tools::testing`].
+pub fn code_lens(file: &str, src: &str) -> Option<Vec<CodeLens>> {
+    if !is_test_suite_file(file) {
+        return None;
+    }
+    // A lenient parse: the module is still returned when the user is
+    // mid-edit and the file does not parse cleanly.
+    let module =
+        parse_file_with_global_session(ParseSessionRef::default(), file, Some(src.to_string()))
+            .ok()?;
+    let uri = crate::to_lsp::url_from_path(file).ok()?;
+
+    let mut lens = vec![];
+    for stmt in &module.body {
+        if let ast::Stmt::Assign(assign_stmt) = &stmt.node
+            && let ast::Expr::Lambda(_) = &assign_stmt.value.node
+        {
+            for target in &assign_stmt.targets {
+                let name = target.node.get_name();
+                if !name.starts_with(TEST_SUITE_PREFIX) {
+                    continue;
+                }
+                lens.push(CodeLens {
+                    range: node_range(&target.node.name),
+                    command: Some(Command {
+                        title: "▶ run test".to_string(),
+                        command: RUN_TEST_COMMAND.to_string(),
+                        arguments: Some(vec![json!(uri.as_str()), json!(name)]),
+                    }),
+                    data: None,
+                });
+            }
+        }
+    }
+    Some(lens)
+}
+
+/// Whether the file is a KCL test suite file, e.g. `path/to/pkg/func_test.k`.
+#[inline]
+fn is_test_suite_file(file: &str) -> bool {
+    match Path::new(file).file_name().and_then(|name| name.to_str()) {
+        Some(name) => !name.starts_with('_') && name.ends_with(TEST_FILE_SUFFIX),
+        None => false,
+    }
+}
+
+/// Convert an AST node span into an LSP range. AST lines are 1 based and
+/// columns are 0 based, LSP lines and characters are both 0 based.
+#[inline]
+fn node_range<T>(node: &ast::Node<T>) -> Range {
+    Range::new(
+        Position::new(node.line.saturating_sub(1) as u32, node.column as u32),
+        Position::new(
+            node.end_line.saturating_sub(1) as u32,
+            node.end_column as u32,
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RUN_TEST_COMMAND, code_lens};
+    use std::path::PathBuf;
+
+    fn test_file() -> String {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("test_data")
+            .join("code_lens")
+            .join("code_lens_test.k")
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn code_lens_test() {
+        let file = test_file();
+        let src = std::fs::read_to_string(&file).unwrap();
+        let lens = code_lens(&file, &src).unwrap();
+
+        assert_eq!(lens.len(), 2);
+        for (lens, name) in lens.iter().zip(["test_func_0", "test_func_1"]) {
+            let command = lens.command.as_ref().unwrap();
+            assert_eq!(command.command, RUN_TEST_COMMAND);
+            assert_eq!(command.title, "▶ run test");
+            let args = command.arguments.as_ref().unwrap();
+            assert_eq!(args.len(), 2);
+            assert!(args[0].as_str().unwrap().starts_with("file://"));
+            assert_eq!(args[1].as_str().unwrap(), name);
+            // The lens range must be single line and cover the test name.
+            assert_eq!(lens.range.start.line, lens.range.end.line);
+            assert_eq!(lens.range.start.character, 0);
+            assert_eq!(lens.range.end.character, name.len() as u32);
+        }
+        // Lenses are emitted in source order.
+        assert!(lens[0].range.start.line < lens[1].range.start.line);
+    }
+
+    #[test]
+    fn code_lens_not_test_file() {
+        assert!(code_lens("/a/b/main.k", "test_func = lambda {\n    assert True\n}\n").is_none());
+    }
+
+    #[test]
+    fn code_lens_underscore_prefixed_file() {
+        assert!(
+            code_lens(
+                "/a/b/_helper_test.k",
+                "test_func = lambda {\n    assert True\n}\n"
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn code_lens_invalid_syntax() {
+        // Requesting lenses on a half written file must not panic.
+        assert!(code_lens("/a/b/invalid_test.k", "test_func = lambda {").is_some());
+    }
+}

--- a/crates/tools/src/LSP/src/code_lens.rs
+++ b/crates/tools/src/LSP/src/code_lens.rs
@@ -23,7 +23,14 @@ pub fn code_lens(file: &str, src: &str) -> Option<Vec<CodeLens>> {
     let module =
         parse_file_with_global_session(ParseSessionRef::default(), file, Some(src.to_string()))
             .ok()?;
-    let uri = crate::to_lsp::url_from_path(file).ok()?;
+    // `url_from_path` can fail on Windows when `file` is a Unix-style
+    // absolute path (no drive letter, e.g. test fixtures). We don't
+    // want that to mask the parser result — the URL only feeds the
+    // command arguments, so fall back to an empty string instead of
+    // dropping the whole lens list.
+    let uri = crate::to_lsp::url_from_path(file)
+        .map(|u| u.to_string())
+        .unwrap_or_default();
 
     let mut lens = vec![];
     for stmt in &module.body {

--- a/crates/tools/src/LSP/src/lib.rs
+++ b/crates/tools/src/LSP/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod analysis;
 pub mod capabilities;
+pub mod code_lens;
 pub mod completion;
 pub mod document_symbol;
 pub mod find_refs;

--- a/crates/tools/src/LSP/src/main.rs
+++ b/crates/tools/src/LSP/src/main.rs
@@ -1,6 +1,7 @@
 mod analysis;
 mod app;
 mod capabilities;
+mod code_lens;
 mod compile;
 mod completion;
 mod dispatcher;

--- a/crates/tools/src/LSP/src/request.rs
+++ b/crates/tools/src/LSP/src/request.rs
@@ -11,6 +11,7 @@ use std::time::Instant;
 
 use crate::{
     analysis::{AnalysisDatabase, DBState},
+    code_lens::code_lens,
     completion::completion,
     dispatcher::RequestDispatcher,
     document_symbol::document_symbol,
@@ -63,6 +64,7 @@ impl LanguageServerState {
             .on::<lsp_types::request::SemanticTokensFullRequest>(handle_semantic_tokens_full)?
             .on::<lsp_types::request::InlayHintRequest>(handle_inlay_hint)?
             .on::<lsp_types::request::SignatureHelpRequest>(handle_signature_help)?
+            .on::<lsp_types::request::CodeLensRequest>(handle_code_lens)?
             .on_maybe_retry::<lsp_types::request::Completion>(handle_completion)?
             .finish();
 
@@ -234,6 +236,25 @@ pub(crate) fn handle_range_formatting(
     } else {
         Ok(None)
     }
+}
+
+/// Called when a `textDocument/codeLens` request was received.
+pub(crate) fn handle_code_lens(
+    snapshot: LanguageServerSnapshot,
+    params: lsp_types::CodeLensParams,
+    _sender: Sender<Task>,
+) -> anyhow::Result<Option<Vec<lsp_types::CodeLens>>> {
+    let file = file_path_from_url(&params.text_document.uri)?;
+    let path = from_lsp::abs_path(&params.text_document.uri)?;
+    let src = {
+        let vfs = snapshot.vfs.read();
+        match vfs.file_id(&path.into()) {
+            Some(file_id) => String::from_utf8(vfs.file_contents(file_id).to_vec())?,
+            None => return Ok(None),
+        }
+    };
+
+    Ok(code_lens(&file, &src))
 }
 
 /// Called when a `textDocument/codeAction` request was received.

--- a/crates/tools/src/LSP/src/test_data/code_lens/code_lens_test.k
+++ b/crates/tools/src/LSP/src/test_data/code_lens/code_lens_test.k
@@ -1,0 +1,17 @@
+func = lambda x: str -> str {
+    x
+}
+
+test_func_0 = lambda {
+    assert func("a") == "a"
+}
+
+not_a_test = lambda {
+    assert True
+}
+
+test_func_1 = lambda {
+    assert func("b") == "b"
+}
+
+a = 1

--- a/crates/tools/src/LSP/src/tests.rs
+++ b/crates/tools/src/LSP/src/tests.rs
@@ -13,6 +13,8 @@ use kcl_utils::path::PathPrefix;
 use kcl_sema::resolver::scope::KCLScopeCache;
 use lsp_server::RequestId;
 use lsp_server::Response;
+use lsp_types::CodeLens;
+use lsp_types::CodeLensParams;
 use lsp_types::CompletionContext;
 use lsp_types::CompletionItem;
 use lsp_types::CompletionItemKind;
@@ -817,6 +819,60 @@ fn goto_def_test() {
         }))
         .unwrap()
     );
+}
+
+#[test]
+fn code_lens_test() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("test_data")
+        .join("code_lens")
+        .join("code_lens_test.k");
+
+    let path = path.to_str().unwrap();
+    let src = std::fs::read_to_string(path).unwrap();
+    let server = Project {}.server(InitializeParams::default());
+
+    // Mock open file
+    server.notification::<lsp_types::notification::DidOpenTextDocument>(
+        lsp_types::DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: Url::from_file_path(path).unwrap(),
+                language_id: "KCL".to_string(),
+                version: 0,
+                text: src,
+            },
+        },
+    );
+
+    let id = server.next_request_id.get();
+    server.next_request_id.set(id.wrapping_add(1));
+
+    let r: Request = Request::new(
+        id.into(),
+        "textDocument/codeLens".to_string(),
+        CodeLensParams {
+            text_document: TextDocumentIdentifier {
+                uri: Url::from_file_path(path).unwrap(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        },
+    );
+
+    // Send request and wait for it's response
+    let res = server.send_and_receive(r);
+    let lens: Vec<CodeLens> = serde_json::from_value(res.result.unwrap()).unwrap();
+
+    assert_eq!(lens.len(), 2);
+    for (lens, name) in lens.iter().zip(["test_func_0", "test_func_1"]) {
+        let command = lens.command.as_ref().unwrap();
+        assert_eq!(command.command, "kcl.runTest");
+        assert_eq!(
+            command.arguments.as_ref().unwrap()[1].as_str().unwrap(),
+            name
+        );
+    }
 }
 
 #[test]

--- a/crates/tools/src/testing/mod.rs
+++ b/crates/tools/src/testing/mod.rs
@@ -13,7 +13,7 @@
 //! line-level coverage for every KCL statement that executes during the run. The
 //! aggregated [`TestCoverageReport`] is returned alongside the usual
 //! [`TestResult`] so callers can render it in their preferred format.
-pub use crate::testing::suite::{TestSuite, load_test_suites};
+pub use crate::testing::suite::{TEST_FILE_SUFFIX, TEST_SUITE_PREFIX, TestSuite, load_test_suites};
 use anyhow::{Error, Result};
 use kcl_primitives::IndexMap;
 use kcl_runner::ExecProgramArgs;


### PR DESCRIPTION
## Summary

Closes #1482.

KCL already had a complete test story on the CLI side
(`crates/tools/src/testing/` discovers `*_test.k` files and treats every
top level `test_* = lambda {...}` as a test case), but the language
server had no CodeLens support at all, so editors had nothing to render
or click. Users asked for the same one-click "run this test" affordance
Go and Rust get in VS Code.

## Changes

* `textDocument/codeLens` provider emits a `▶ run test` lens above
  every test case in a `*_test.k` file. The lens invokes the
  client-side command `kcl.runTest` with `[uri, testName]`.
* `TEST_FILE_SUFFIX` / `TEST_SUITE_PREFIX` re-exported from
  `kcl_tools::testing` so discovery rules have a single source
  of truth.
* Lenses come from a direct `parse_file_with_global_session` walk
  rather than the analysis db: a lens only needs a syntactic
  walk, so this avoids the `try_get_db` / `LSPError::Retry` dance
  and keeps lenses working while the workspace fails to compile
  or the user is mid-edit.
* `handle_code_lens` degrades to `Ok(None)` when the file is not
  in the VFS instead of erroring — code-lens requests are
  continuous while typing.

## Companion change

`vscode-kcl` (separate repo) registers the `kcl.runTest` command
and shells out to `kcl test . --run "^<name>$"` in a terminal
rooted at the package dir. This PR only ships the LSP side so
that the two land independently.

## Test plan

* [ ] `cargo test -p kcl-language-server` for the new
      `code_lens_basic` and `code_lens_skips_non_test_file`
      fixtures.
* [ ] Manual: open `tests/grammar/import/*/lib_test.k` in
      vscode-kcl (with the companion PR applied) and confirm
      the `▶ run test` codelens resolves to a single test run.