### PR TITLE
feat(lint): support `./...` to lint all packages

### DIFF
--- a/crates/tools/src/lint/mod.rs
+++ b/crates/tools/src/lint/mod.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use kcl_error::{Diagnostic, Handler};
-use kcl_parser::{LoadProgramOptions, ParseSession, load_program};
+use kcl_parser::{LoadProgramOptions, ParseSession, get_kcl_files, load_program};
 use kcl_primitives::IndexSet;
 use kcl_runtime::PanicInfo;
 use kcl_sema::resolver::resolve_program_with_opts;
@@ -13,7 +15,12 @@ mod tests;
 /// # Parameters
 ///
 /// `file`: [&str]
-///     The File that need to be check
+///     The File that need to be check. A path ending with `/...` (e.g. `./...`)
+///     recursively lints every package under the root directory, like
+///     `go build ./...`: all `.k` files are collected, grouped by their
+///     directory (one directory is one package) and each package is linted
+///     as its own program, so packages that are not imported by the entry
+///     file are also checked and name clashes between packages are allowed.
 ///
 /// `opts`: Option<LoadProgramOptions>
 ///     The compilation parameters of KCL, same as the compilation process
@@ -65,8 +72,89 @@ mod tests;
 ///     }
 /// ]
 /// ```
-#[allow(clippy::arc_with_non_send_sync)]
 pub fn lint_files(
+    files: &[&str],
+    opts: Option<LoadProgramOptions>,
+) -> (IndexSet<Diagnostic>, IndexSet<Diagnostic>) {
+    if files.iter().any(|f| recursive_root(f).is_some()) {
+        return lint_all_packages(files, opts);
+    }
+    lint_package(files, opts)
+}
+
+/// Expand `./...`-style patterns and lint every package found under their roots.
+///
+/// All the `.k` files collected from the patterns (plus the plain paths given
+/// alongside them) are grouped by parent directory, since one directory is one
+/// KCL package, and each group is linted as its own program. This mirrors
+/// `go build ./...`: packages unreachable from any entry file are still
+/// checked, while symbols defined in distinct packages never collide.
+fn lint_all_packages(
+    files: &[&str],
+    opts: Option<LoadProgramOptions>,
+) -> (IndexSet<Diagnostic>, IndexSet<Diagnostic>) {
+    let mut packages: BTreeMap<PathBuf, Vec<String>> = BTreeMap::new();
+    for file in files {
+        match recursive_root(file) {
+            Some(root) => match get_kcl_files(root, true) {
+                Ok(kcl_files) => {
+                    for kcl_file in kcl_files {
+                        packages
+                            .entry(
+                                Path::new(&kcl_file)
+                                    .parent()
+                                    .unwrap_or(Path::new(""))
+                                    .to_path_buf(),
+                            )
+                            .or_default()
+                            .push(kcl_file);
+                    }
+                }
+                Err(err) => {
+                    return Handler::default()
+                        .add_panic_info(&PanicInfo::from(err.to_string()))
+                        .classification();
+                }
+            },
+            None => {
+                packages
+                    .entry(
+                        Path::new(file)
+                            .parent()
+                            .unwrap_or(Path::new(""))
+                            .to_path_buf(),
+                    )
+                    .or_default()
+                    .push(file.to_string());
+            }
+        }
+    }
+    let mut errors = IndexSet::default();
+    let mut warnings = IndexSet::default();
+    for (_, package) in packages.iter_mut() {
+        package.sort();
+        package.dedup();
+        let entries: Vec<&str> = package.iter().map(|f| f.as_str()).collect();
+        let (errs, warns) = lint_package(&entries, opts.clone());
+        errors.extend(errs);
+        warnings.extend(warns);
+    }
+    (errors, warnings)
+}
+
+/// For a `./...`-style path, return the root directory the pattern scans;
+/// return `None` for ordinary paths.
+fn recursive_root(path: &str) -> Option<&str> {
+    if Path::new(path).file_name()? == "..." {
+        let root = Path::new(path).parent()?.to_str()?;
+        Some(if root.is_empty() { "." } else { root })
+    } else {
+        None
+    }
+}
+
+#[allow(clippy::arc_with_non_send_sync)]
+fn lint_package(
     files: &[&str],
     opts: Option<LoadProgramOptions>,
 ) -> (IndexSet<Diagnostic>, IndexSet<Diagnostic>) {

--- a/crates/tools/src/lint/test_data/lint_all/main.k
+++ b/crates/tools/src/lint/test_data/lint_all/main.k
@@ -1,0 +1,4 @@
+import math
+
+schema S:
+    p: int

--- a/crates/tools/src/lint/test_data/lint_all/pkg/sub/orphan.k
+++ b/crates/tools/src/lint/test_data/lint_all/pkg/sub/orphan.k
@@ -1,0 +1,3 @@
+import math
+
+y = 2

--- a/crates/tools/src/lint/test_data/lint_all/pkg/wrapper.k
+++ b/crates/tools/src/lint/test_data/lint_all/pkg/wrapper.k
@@ -1,0 +1,3 @@
+import .sub.orphan
+
+z = orphan.y

--- a/crates/tools/src/lint/test_data/lint_all/pkg_dup/dup.k
+++ b/crates/tools/src/lint/test_data/lint_all/pkg_dup/dup.k
@@ -1,0 +1,3 @@
+# `S` is also defined in the root package: distinct packages must not collide.
+schema S:
+    q: int

--- a/crates/tools/src/lint/tests.rs
+++ b/crates/tools/src/lint/tests.rs
@@ -68,3 +68,63 @@ fn test_unused_check_for_each_file() {
         path.to_str().unwrap().to_string()
     );
 }
+
+#[test]
+fn test_lint_all_packages() {
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    root.push("src");
+    root.push("lint");
+    root.push("test_data");
+    root.push("lint_all");
+    let pattern = format!("{}/...", root.to_str().unwrap());
+    let (errors, warnings) = lint_files(&[pattern.as_str()], None);
+    // Every package is linted on its own, so `S` defined both in the root
+    // package and in `pkg_dup` is not a redefinition, and `pkg/sub/orphan.k`,
+    // which no entry file imports, is still checked.
+    assert_eq!(
+        errors.len(),
+        0,
+        "{:?}",
+        errors
+            .iter()
+            .map(|e| e.messages[0].message.clone())
+            .collect::<Vec<String>>()
+    );
+    let msgs = [
+        ("Module 'math' imported but unused", "lint_all/main.k"),
+        (
+            "Module 'math' imported but unused",
+            "lint_all/pkg/sub/orphan.k",
+        ),
+    ];
+    assert_eq!(warnings.len(), msgs.len());
+    for (diag, (m, file)) in warnings.iter().zip(msgs.iter()) {
+        assert_eq!(diag.messages[0].message, m.to_string());
+        assert!(diag.messages[0].range.0.filename.ends_with(file));
+    }
+}
+
+#[test]
+fn test_lint_dir_checks_root_package_only() {
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    root.push("src");
+    root.push("lint");
+    root.push("test_data");
+    root.push("lint_all");
+    let (errors, warnings) = lint_files(&[root.to_str().unwrap()], None);
+    // A plain directory keeps its existing meaning: only the root package
+    // (the files directly in it) takes part in the lint.
+    assert_eq!(errors.len(), 0);
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        warnings[0].messages[0].message,
+        "Module 'math' imported but unused".to_string()
+    );
+    assert!(
+        warnings[0].messages[0]
+            .range
+            .0
+            .filename
+            .ends_with("lint_all/main.k")
+    );
+}

--- a/crates/tools/src/lint/tests.rs
+++ b/crates/tools/src/lint/tests.rs
@@ -100,7 +100,8 @@ fn test_lint_all_packages() {
     assert_eq!(warnings.len(), msgs.len());
     for (diag, (m, file)) in warnings.iter().zip(msgs.iter()) {
         assert_eq!(diag.messages[0].message, m.to_string());
-        assert!(diag.messages[0].range.0.filename.ends_with(file));
+        // Compare path components, the separator differs between platforms.
+        assert!(std::path::Path::new(&diag.messages[0].range.0.filename).ends_with(file));
     }
 }
 
@@ -121,10 +122,7 @@ fn test_lint_dir_checks_root_package_only() {
         "Module 'math' imported but unused".to_string()
     );
     assert!(
-        warnings[0].messages[0]
-            .range
-            .0
-            .filename
+        std::path::Path::new(&warnings[0].messages[0].range.0.filename)
             .ends_with("lint_all/main.k")
     );
 }


### PR DESCRIPTION
## Summary

- `kcl lint` only checked the packages reachable from the entry files: pass a directory and packages that are never imported (dead code, WIP modules) were silently skipped. Issue #1691 asks for a `go build ./...`-style mode.
- A path ending with `/...` (e.g. `./...`, `pkg/...`, `/abs/path/...`) now recursively collects every `.k` file under the root, groups them by directory (one directory = one KCL package) and lints each package as its own program, then merges the diagnostics.
- Linting each package separately keeps symbols defined in distinct packages from colliding (mirrors `go build ./...`, where each package is compiled on its own).
- Plain files and plain directories keep their existing meaning — no behavior change for current callers of `lint_files` / the `LintPath` API.

Fixes #1691

## Test plan

- [x] `test_lint_all_packages`: on the new `test_data/lint_all` fixture, `lint_files(&[".../lint_all/..."])` reports the unused import in the root `main.k` **and** in the unreachable `pkg/sub/orphan.k`, with zero errors even though `schema S` is defined both in the root package and in `pkg_dup` (package isolation).
- [x] `test_lint_dir_checks_root_package_only`: a plain directory still lints only the root package (documented unchanged behavior).
- [x] `cargo test -p kcl-tools --lib` (67 passed) and `cargo test -p kcl-api` incl. `test_c_api_lint_path` and the `lint_path` doctest.
- [x] `cargo fmt` / `cargo clippy -p kcl-tools` clean.

Note for reviewers: the user-facing `kcl lint` command in kcl-lang/cli currently goes through `ExecProgram` with `compile_only`; wiring its argument through `LintPath` (or expanding the pattern there) is a small follow-up in that repo — this PR provides the API-level support He1pa pointed at in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)