### PR TITLE
fix(runtime): apply width, alignment and fill when formatting string values (fixes #2176)

### DIFF
--- a/crates/runtime/src/value/val_fmt.rs
+++ b/crates/runtime/src/value/val_fmt.rs
@@ -643,6 +643,64 @@ impl FormatSpec {
             }
         })
     }
+
+    /// Format a string value according to the format spec. Strings support the
+    /// `[[fill]align][width][.precision][s]` fields. Unlike numbers they default
+    /// to left alignment, and `precision` is treated as a maximum length that
+    /// truncates the string, matching Python's `str.format` behavior.
+    pub(crate) fn format_str(&self, s: &str) -> Result<String, &'static str> {
+        // Only the string presentation type (or none) applies to strings.
+        match self.format_type {
+            None | Some(FormatType::String) => {}
+            _ => return Err("Unknown format code for object of type 'str'"),
+        }
+        if self.sign.is_some() {
+            return Err("Sign not allowed in string format specifier");
+        }
+        if self.alternate_form {
+            return Err("Alternate form (#) not allowed in string format specifier");
+        }
+        if let Some(FormatAlign::AfterSign) = self.align {
+            return Err("'=' alignment not allowed in string format specifier");
+        }
+        // `precision` truncates the string to at most that many characters.
+        let truncated: String = match self.precision {
+            Some(precision) => s.chars().take(precision).collect(),
+            None => s.to_string(),
+        };
+        let align = self.align.unwrap_or(FormatAlign::Left);
+        // Count characters (code points), not bytes, so widths are correct for
+        // multi-byte content.
+        let num_chars = truncated.chars().count();
+        let fill_char = self.fill.unwrap_or(' ');
+        let fill_chars_needed: i32 = self
+            .width
+            .map_or(0, |w| cmp::max(0, (w as i32) - (num_chars as i32)));
+        Ok(match align {
+            FormatAlign::Left => format!(
+                "{}{}",
+                truncated,
+                FormatSpec::compute_fill_string(fill_char, fill_chars_needed)
+            ),
+            FormatAlign::Right => format!(
+                "{}{}",
+                FormatSpec::compute_fill_string(fill_char, fill_chars_needed),
+                truncated
+            ),
+            FormatAlign::Center => {
+                let left_fill_chars_needed = fill_chars_needed / 2;
+                let right_fill_chars_needed = fill_chars_needed - left_fill_chars_needed;
+                format!(
+                    "{}{}{}",
+                    FormatSpec::compute_fill_string(fill_char, left_fill_chars_needed),
+                    truncated,
+                    FormatSpec::compute_fill_string(fill_char, right_fill_chars_needed)
+                )
+            }
+            // Rejected above for strings.
+            FormatAlign::AfterSign => unreachable!(),
+        })
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -1042,6 +1100,12 @@ impl ValueRef {
                     Err(err) => panic!("{}", err),
                 }
             }
+            Value::str_value(v) => {
+                match FormatSpec::parse(spec).and_then(|format_spec| format_spec.format_str(v)) {
+                    Ok(string) => string,
+                    Err(err) => panic!("{}", err),
+                }
+            }
             _ => self.to_string(),
         }
     }
@@ -1063,6 +1127,18 @@ mod test_value_fmt {
                 r#"[["0","1"],{ "Hello": "World" }]"#,
                 "\"00, 11, HelloWorld\"",
             ),
+            // String field width, alignment, fill and precision (issue: the
+            // format spec was previously ignored for string arguments).
+            (r#""{:>6}""#, r#"["ab"]"#, "\"    ab\""),
+            (r#""{:<6}""#, r#"["ab"]"#, "\"ab    \""),
+            (r#""{:^6}""#, r#"["ab"]"#, "\"  ab  \""),
+            (r#""{:*>6}""#, r#"["ab"]"#, "\"****ab\""),
+            (r#""{:-^7}""#, r#"["ab"]"#, "\"--ab---\""),
+            // Strings default to left alignment when only a width is given.
+            (r#""{:6}""#, r#"["ab"]"#, "\"ab    \""),
+            // Precision truncates a string to at most that many characters.
+            (r#""{:.3}""#, r#"["abcdef"]"#, "\"abc\""),
+            (r#""{:>8.3}""#, r#"["abcdef"]"#, "\"     abc\""),
         ];
         for (format_string, args, expected) in cases {
             let format_string = FormatString::from_str(format_string).unwrap();

--- a/tests/grammar/builtins/str/format/main.k
+++ b/tests/grammar/builtins/str/format/main.k
@@ -1,3 +1,8 @@
 a = "{} {}".format("Hello", "World")
 b = "{:.0f}".format(1.0)
 c = "{:.1f} {:.0f}".format(1.0, 2.0)
+d = "[{:>6}]".format("ab")
+e = "[{:<6}]".format("ab")
+f = "[{:^6}]".format("ab")
+g = "[{:*>6}]".format("ab")
+h = "[{:.3}]".format("abcdef")

--- a/tests/grammar/builtins/str/format/stdout.golden
+++ b/tests/grammar/builtins/str/format/stdout.golden
@@ -1,3 +1,8 @@
 a: Hello World
 b: '1'
 c: 1.0 2
+d: '[    ab]'
+e: '[ab    ]'
+f: '[  ab  ]'
+g: '[****ab]'
+h: '[abc]'


### PR DESCRIPTION
## What this PR does

Fixes #2176.

`str.format` was ignoring the format spec for string arguments. Width, alignment (`<`, `>`, `^`), a fill character, a bare width, and `.precision` all had no effect on strings, while numbers worked fine.

Before:

```python
"{:>6}".format("ab")    # "ab"      (expected "    ab")
"{:^6}".format("ab")    # "ab"      (expected "  ab  ")
"{:*>6}".format("ab")   # "ab"      (expected "****ab")
"{:.3}".format("abcdef")# "abcdef"  (expected "abc")
```

After, these match Python's `str.format`:

```python
"{:>6}".format("ab")    # "    ab"
"{:^6}".format("ab")    # "  ab  "
"{:*>6}".format("ab")   # "****ab"
"{:.3}".format("abcdef")# "abc"
"{:6}".format("ab")     # "ab    "   (strings default to left alignment)
```

## Root cause

In `crates/runtime/src/value/val_fmt.rs`, `to_string_with_spec` applied the parsed `FormatSpec` for `int` and `float` values but fell through to a plain `to_string()` for string values, so the spec was dropped.

## Fix

Adds `FormatSpec::format_str`, which mirrors the numeric alignment path but:

- defaults to left alignment, the way Python formats strings,
- treats `precision` as a maximum length that truncates the string,
- rejects options that do not apply to strings (a numeric presentation type, a sign, the alternate form `#`, and `=` alignment),
- counts characters rather than bytes for the width, so multi-byte content is padded correctly.

Number formatting is untouched.

## Tests

- Runtime unit cases added to `test_string_format` (alignment, fill, bare width, precision).
- Grammar cases added to `tests/grammar/builtins/str/format`.

## Verification

- `cargo test -p kcl-runtime` passes
- Full grammar suite (`tests/grammar`) 1610 passed, no regressions
- `cargo fmt --check` clean, no new clippy warnings