### PR TITLE
refactor(compiler): unify pkgpath to filesystem path conversion

### DIFF
--- a/crates/config/src/cache.rs
+++ b/crates/config/src/cache.rs
@@ -3,7 +3,7 @@ extern crate chrono;
 use super::modfile::KCL_FILE_SUFFIX;
 use anyhow::Result;
 use kcl_utils::fslock::open_lock_file;
-use kcl_utils::pkgpath::{parse_external_pkg_name, rm_external_pkg_name};
+use kcl_utils::pkgpath::{parse_external_pkg_name, pkgpath_to_path_buf, rm_external_pkg_name};
 use md5::{Digest, Md5};
 use serde::{Serialize, de::DeserializeOwned};
 use std::collections::HashMap;
@@ -235,12 +235,15 @@ fn get_cache_info(path_str: &str) -> CacheInfo {
 }
 
 pub fn get_pkg_realpath_from_pkgpath(root: &str, pkgpath: &str) -> String {
-    let filepath = format!("{}/{}", root, pkgpath.replace('.', "/"));
-    let filepath_with_suffix = format!("{}{}", filepath, KCL_FILE_SUFFIX);
-    if Path::new(&filepath_with_suffix).is_file() {
-        filepath_with_suffix
+    let filepath = pkgpath_to_path_buf(Path::new(root), pkgpath);
+    let mut filepath_with_suffix = filepath.clone();
+    filepath_with_suffix
+        .as_mut_os_string()
+        .push(KCL_FILE_SUFFIX);
+    if filepath_with_suffix.is_file() {
+        filepath_with_suffix.to_string_lossy().to_string()
     } else {
-        filepath
+        filepath.to_string_lossy().to_string()
     }
 }
 

--- a/crates/config/src/vfs.rs
+++ b/crates/config/src/vfs.rs
@@ -40,15 +40,17 @@ pub fn fix_import_path(root: &str, filepath: &str, import_path: &str) -> String 
     // abspath: import path.to.sub
     // fix_import_path(root, "path/to/app/file.k", "path.to.sub") => path.to.sub
 
+    // Absolute import paths are returned as-is; no need to canonicalize
+    // the file paths below.
+    if !import_path.starts_with('.') {
+        return import_path.to_string();
+    }
+
     // Use canonicalize to convert the path to absolute path
     // avoid the symbolic link issue caused the file not found
 
     let filepath = Path::new(filepath).adjust_canonicalization();
     let root = Path::new(root).adjust_canonicalization();
-
-    if !import_path.starts_with('.') {
-        return import_path.to_string();
-    }
 
     // Filepath to pkgpath
     let pkgpath = {

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -14,6 +14,7 @@ use kcl_config::{
 };
 use kcl_parser::{LoadProgramOptions, get_kcl_files};
 use kcl_utils::path::PathPrefix;
+use kcl_utils::pkgpath::pkgpath_to_rel_path_buf;
 use std::iter;
 use std::{collections::HashMap, env};
 use std::{
@@ -341,9 +342,15 @@ pub fn get_pkg_list(pkgpath: &str) -> Result<Vec<String>> {
         pkgpath.to_string()
     };
 
-    let include_sub_pkg = pkgpath.ends_with("/...");
+    // Accept both `/...` and `\...` so Windows-style inputs (e.g. `.\...`)
+    // enable sub-package walking as well.
+    let include_sub_pkg = pkgpath.ends_with("/...") || pkgpath.ends_with("\\...");
     let pkgpath = if include_sub_pkg {
-        pkgpath.trim_end_matches("/...").to_string()
+        let trimmed = pkgpath
+            .strip_suffix("...")
+            .map(|p| p.strip_suffix(['/', '\\']).unwrap_or(p))
+            .unwrap_or(pkgpath.as_str());
+        trimmed.to_string()
     } else {
         pkgpath
     };
@@ -365,7 +372,9 @@ pub fn get_pkg_list(pkgpath: &str) -> Result<Vec<String>> {
             if Path::new(&pkgpath).is_absolute() {
                 pkgpath.clone()
             } else if !pkgpath.contains('/') && !pkgpath.contains('\\') {
-                pkgpath.replace('.', "/")
+                pkgpath_to_rel_path_buf(&pkgpath)
+                    .to_string_lossy()
+                    .to_string()
             } else {
                 let pkgroot =
                     get_pkg_root(cwd.to_str().ok_or(anyhow::anyhow!("cwd path not found"))?)

--- a/crates/driver/src/toolchain.rs
+++ b/crates/driver/src/toolchain.rs
@@ -2,7 +2,7 @@ use crate::{kcl, lookup_the_nearest_file_dir};
 use anyhow::{Result, bail};
 use kcl_config::modfile::KCL_MOD_FILE;
 use kcl_parser::LoadProgramOptions;
-use kcl_utils::pkgpath::rm_external_pkg_name;
+use kcl_utils::pkgpath::{pkgpath_to_rel_path_buf, rm_external_pkg_name};
 use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
 use std::{collections::HashMap, path::PathBuf, process::Command};
@@ -220,6 +220,6 @@ pub fn get_real_path_from_external(
     real_path = real_path.join(pkg_root);
 
     let pkgpath = rm_external_pkg_name(pkgpath).unwrap_or_default();
-    pkgpath.split('.').for_each(|s| real_path.push(s));
+    real_path.push(pkgpath_to_rel_path_buf(&pkgpath));
     real_path
 }

--- a/crates/parser/src/entry.rs
+++ b/crates/parser/src/entry.rs
@@ -320,10 +320,11 @@ pub fn get_compile_entries_from_paths(
         let mut idx = 0usize;
         for code in k_code_queue.drain(..) {
             let synthetic = if idx == 0 {
-                format!("{}/__main__.k", root)
+                Path::new(&root).join("__main__.k")
             } else {
-                format!("{}/__main__{}.k", root, idx)
+                Path::new(&root).join(format!("__main__{}.k", idx))
             };
+            let synthetic = synthetic.to_string_lossy().to_string();
             entry.push_k_code(Some(code));
             entry.extend_k_files(vec![synthetic]);
             idx += 1;

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -28,6 +28,7 @@ use kcl_primitives::IndexMap;
 use kcl_sema::plugin::PLUGIN_MODULE_PREFIX;
 use kcl_utils::path::PathPrefix;
 use kcl_utils::pkgpath::parse_external_pkg_name;
+use kcl_utils::pkgpath::pkgpath_to_path_buf;
 use kcl_utils::pkgpath::rm_external_pkg_name;
 
 use anyhow::Result;
@@ -623,8 +624,7 @@ fn pkg_exists_in_path(path: &str, pkgpath: &str, load_cache: &mut ParseLoadCache
     if let Some(exists) = load_cache.pkg_exists_in_path.get(&cache_key) {
         return *exists;
     }
-    let mut pathbuf = PathBuf::from(path);
-    pkgpath.split('.').for_each(|s| pathbuf.push(s));
+    let pathbuf = pkgpath_to_path_buf(Path::new(path), pkgpath);
     let exists = pathbuf.exists() || pathbuf.with_extension(KCL_FILE_EXTENSION).exists();
     load_cache.pkg_exists_in_path.insert(cache_key, exists);
     exists
@@ -648,10 +648,7 @@ fn pkg_exists_in_path(path: &str, pkgpath: &str, load_cache: &mut ParseLoadCache
 /// forms refer to genuinely different sets of files, and we leave the
 /// original pkgpath untouched to preserve the existing semantics.
 fn canonical_pkg_path(pkgroot: &str, pkgpath: &str) -> String {
-    let mut pathbuf = PathBuf::from(pkgroot);
-    for s in pkgpath.split('.') {
-        pathbuf.push(s);
-    }
+    let pathbuf = pkgpath_to_path_buf(Path::new(pkgroot), pkgpath);
     // Already a directory package: nothing to canonicalize.
     if pathbuf.is_dir() {
         return pkgpath.to_string();
@@ -776,12 +773,7 @@ fn get_pkg_kfile_list(
         return Ok(k_files.clone());
     }
 
-    let mut pathbuf = std::path::PathBuf::new();
-    pathbuf.push(pkgroot);
-
-    for s in pkgpath.split('.') {
-        pathbuf.push(s);
-    }
+    let pathbuf = pkgpath_to_path_buf(std::path::Path::new(pkgroot), pkgpath);
 
     let abspath = canonicalize_path_cached(pathbuf.as_path(), load_cache);
     if abspath.exists() {

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -654,10 +654,19 @@ fn test_get_compile_entries_from_k_code_list_only() {
     assert_eq!(entry.path(), "/tmp/lib217");
     assert_eq!(entry.get_k_files().len(), 2);
     assert_eq!(entry.get_k_codes().len(), 2);
-    assert_eq!(entry.get_k_files()[0], "/tmp/lib217/__main__.k".to_string());
+    assert_eq!(
+        entry.get_k_files()[0],
+        Path::new("/tmp/lib217")
+            .join("__main__.k")
+            .to_string_lossy()
+            .to_string()
+    );
     assert_eq!(
         entry.get_k_files()[1],
-        "/tmp/lib217/__main__1.k".to_string()
+        Path::new("/tmp/lib217")
+            .join("__main__1.k")
+            .to_string_lossy()
+            .to_string()
     );
     assert_eq!(entry.get_k_codes()[0].as_deref(), Some("a = 1"));
     assert_eq!(entry.get_k_codes()[1].as_deref(), Some("b = 2"));

--- a/crates/sema/src/resolver/import.rs
+++ b/crates/sema/src/resolver/import.rs
@@ -15,7 +15,7 @@ use std::{cell::RefCell, path::Path};
 
 use super::scope::{Scope, ScopeKind, ScopeObject, ScopeObjectKind};
 use kcl_ast::pos::GetPos;
-use kcl_utils::pkgpath::parse_external_pkg_name;
+use kcl_utils::pkgpath::{parse_external_pkg_name, pkgpath_to_path_buf};
 
 impl<'ctx> Resolver<'ctx> {
     /// Check import error
@@ -39,8 +39,7 @@ impl<'ctx> Resolver<'ctx> {
                         if pkgpath.starts_with(PLUGIN_MODULE_PREFIX) {
                             continue;
                         }
-                        let real_path =
-                            Path::new(&self.program.root).join(pkgpath.replace('.', "/"));
+                        let real_path = pkgpath_to_path_buf(Path::new(&self.program.root), pkgpath);
                         if !self.program.pkgs.contains_key(pkgpath) {
                             self.ctx.invalid_pkg_scope.insert(pkgpath.to_string());
                             if real_path.exists() {

--- a/crates/utils/src/pkgpath.rs
+++ b/crates/utils/src/pkgpath.rs
@@ -1,6 +1,7 @@
 //! This file primarily offers utils for working with kcl package paths.
 
 use anyhow::{Result, anyhow};
+use std::path::{Path, PathBuf};
 
 /// Remove the external package name prefix from the current import absolute path.
 ///
@@ -30,5 +31,75 @@ pub fn parse_external_pkg_name(pkgpath: &str) -> Result<String> {
     match names.next() {
         Some(it) => Ok(it.to_string()),
         None => Err(anyhow!("Invalid external package name `{}`", pkgpath)),
+    }
+}
+
+/// Convert a dotted pkgpath (e.g. `a.b.c`) into a relative path (e.g.
+/// `a/b/c` on Unix, `a\b\c` on Windows) by appending each segment to an
+/// empty path buffer with the platform-correct separator.
+pub fn pkgpath_to_rel_path_buf(pkgpath: &str) -> PathBuf {
+    let mut path = PathBuf::new();
+    for s in pkgpath.split('.') {
+        path.push(s);
+    }
+    path
+}
+
+/// Append each segment of a dotted pkgpath (e.g. `a.b.c`) to `root` with
+/// the platform-correct separator (e.g. `root/a/b/c` on Unix,
+/// `root\a\b\c` on Windows).
+pub fn pkgpath_to_path_buf(root: &Path, pkgpath: &str) -> PathBuf {
+    let mut path = root.to_path_buf();
+    for s in pkgpath.split('.') {
+        path.push(s);
+    }
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::MAIN_SEPARATOR_STR;
+
+    #[test]
+    fn test_pkgpath_to_rel_path_buf() {
+        let sep = MAIN_SEPARATOR_STR;
+        assert_eq!(
+            pkgpath_to_rel_path_buf("a.b.c"),
+            PathBuf::from(["a", "b", "c"].join(sep))
+        );
+        assert_eq!(pkgpath_to_rel_path_buf("a"), PathBuf::from("a"));
+        // An empty pkgpath yields an empty relative path.
+        assert_eq!(pkgpath_to_rel_path_buf(""), PathBuf::new());
+        // Leading/trailing dots produce empty segments, which `PathBuf::push`
+        // skips without adding separators.
+        assert_eq!(
+            pkgpath_to_rel_path_buf(".a.b."),
+            PathBuf::from(["a", "b"].join(sep))
+        );
+    }
+
+    #[test]
+    fn test_pkgpath_to_path_buf() {
+        let sep = MAIN_SEPARATOR_STR;
+        assert_eq!(
+            pkgpath_to_path_buf(Path::new("root"), "a.b.c"),
+            PathBuf::from(["root", "a", "b", "c"].join(sep))
+        );
+        assert_eq!(
+            pkgpath_to_path_buf(Path::new("root"), "a"),
+            PathBuf::from("root").join("a")
+        );
+        // An empty pkgpath leaves the root untouched.
+        assert_eq!(
+            pkgpath_to_path_buf(Path::new("root"), ""),
+            PathBuf::from("root")
+        );
+        // An absolute root keeps its prefix.
+        let abs = if cfg!(windows) { r"C:\root" } else { "/root" };
+        assert_eq!(
+            pkgpath_to_path_buf(Path::new(abs), "a.b"),
+            Path::new(abs).join(["a", "b"].join(sep))
+        );
     }
 }

--- a/tests/grammar/import/import_syntax_error_0/app-main/stderr.golden
+++ b/tests/grammar/import/import_syntax_error_0/app-main/stderr.golden
@@ -8,7 +8,7 @@ error[E2F04]: CannotFindModule
  --> ${CWD}/main.k:1:1
   |
 1 | import .some0..pkg1 as some00  # some0 not found in app-main package
-  | ^ Cannot find the module .some0..pkg1 from ${CWD}/some0//pkg1
+  | ^ Cannot find the module .some0..pkg1 from ${CWD}/some0/pkg1
   |
 suggestion: try 'kcl mod add app-main' to download the missing package
 suggestion: browse more packages at 'https://artifacthub.io'


### PR DESCRIPTION
## Summary

- Add two shared helpers in `kcl-utils` (`pkgpath_to_path_buf`, `pkgpath_to_rel_path_buf`) that convert dotted pkgpaths (`a.b.c`) into filesystem paths using the platform-correct separator, and route all compiler-side conversions through them. Hardcoded `/` conversions have been a recurring source of Windows bugs (most recently #2173).
- Fix 5 platform-incorrect conversion sites:
  - `crates/config/src/cache.rs` — `get_pkg_realpath_from_pkgpath`
  - `crates/driver/src/lib.rs` — `get_pkg_list` dotted-path conversion; the `/...` suffix now also accepts `\...` so Windows-style inputs (e.g. `.\...`) work
  - `crates/sema/src/resolver/import.rs` — `resolve_import`
  - `crates/parser/src/entry.rs` — synthetic `__main__.k` entry filename for inline-code compilation
- Deduplicate the hand-written `split('.')` push loops in `kcl-parser` (`pkg_exists_in_path`, `canonical_pkg_path`, `get_pkg_kfile_list`) and the driver toolchain (`get_real_path_from_external`).
- Micro-cleanup in `fix_import_path` (`crates/config/src/vfs.rs`): move the absolute-import early return before the two `adjust_canonicalization` calls it never uses.

LSP/bundle code is intentionally left out of scope (it has its own path normalization strategy).

## Notes

One observable behavior change: for malformed dotted import paths (e.g. `.some0..pkg1`), the "Cannot find the module" error now reports a normalized path (`some0/pkg1` instead of the double-slashed `some0//pkg1` produced by the old `replace('.', "/")`). The corresponding grammar golden file is updated.

## Test plan

- [x] `cargo test -p kcl-utils -p kcl-config -p kcl-parser -p kcl-sema -p kcl-driver`
- [x] `cargo clippy --workspace` — no new warnings
- [x] Full grammar suite (`tests/grammar`, 1610/1610) against a freshly built binary
- [ ] Windows CI covers the platform-specific code paths

Part of #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)