### PR TITLE
fix(driver): restore get_pkg_list match binding + dedupe LSP path conversion

### DIFF
--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -363,7 +363,14 @@ pub fn get_pkg_list(pkgpath: &str) -> Result<Vec<String>> {
         return Ok(Vec::new());
     }
 
-    match pkgpath.chars().next() {
+    // Restore the missing `let` binding that was lost in early history
+    // (#2178 follow-up): without it, the cwd-join for relative paths and
+    // the dotted-pkgpath → filesystem-path conversion below are computed
+    // and immediately thrown away, leaving `pkgpath` as the raw input
+    // string (e.g. `./...`, `a.b.c`). Callers like the test loader need
+    // the resolved directory path to enumerate test files, so wire the
+    // match result through.
+    let pkgpath = match pkgpath.chars().next() {
         Some('.') => {
             let pkgpath = Path::new(&cwd).join(&pkgpath);
             pkgpath.to_string_lossy().to_string()

--- a/crates/driver/src/tests.rs
+++ b/crates/driver/src/tests.rs
@@ -173,12 +173,8 @@ fn test_get_pkg_list() {
         "expected absolute path, got {:?}",
         single[0]
     );
-    let expected_single =
-        std::fs::canonicalize("./src/test_data/pkg_list").unwrap();
-    assert_eq!(
-        std::fs::canonicalize(&single[0]).unwrap(),
-        expected_single
-    );
+    let expected_single = std::fs::canonicalize("./src/test_data/pkg_list").unwrap();
+    assert_eq!(std::fs::canonicalize(&single[0]).unwrap(), expected_single);
 
     // Recursive walk: the returned entries must all be absolute and
     // resolve to real directories.

--- a/crates/driver/src/tests.rs
+++ b/crates/driver/src/tests.rs
@@ -164,9 +164,33 @@ fn test_native_fetch_metadata_invalid() {
 
 #[test]
 fn test_get_pkg_list() {
-    assert_eq!(get_pkg_list("./src/test_data/pkg_list/").unwrap().len(), 1);
-    assert_eq!(
-        get_pkg_list("./src/test_data/pkg_list/...").unwrap().len(),
-        3
+    // Single package: the binding fix in `get_pkg_list` should resolve
+    // the relative input to an absolute directory and return it as-is.
+    let single = get_pkg_list("./src/test_data/pkg_list/").unwrap();
+    assert_eq!(single.len(), 1);
+    assert!(
+        PathBuf::from(&single[0]).is_absolute(),
+        "expected absolute path, got {:?}",
+        single[0]
     );
+    let expected_single =
+        std::fs::canonicalize("./src/test_data/pkg_list").unwrap();
+    assert_eq!(
+        std::fs::canonicalize(&single[0]).unwrap(),
+        expected_single
+    );
+
+    // Recursive walk: the returned entries must all be absolute and
+    // resolve to real directories.
+    let recursive = get_pkg_list("./src/test_data/pkg_list/...").unwrap();
+    assert_eq!(recursive.len(), 3);
+    for entry in &recursive {
+        let p = PathBuf::from(entry);
+        assert!(p.is_absolute(), "expected absolute path, got {:?}", entry);
+        assert!(
+            std::fs::canonicalize(&p).unwrap().is_dir(),
+            "{:?} is not a directory",
+            entry
+        );
+    }
 }

--- a/crates/driver/src/toolchain.rs
+++ b/crates/driver/src/toolchain.rs
@@ -2,7 +2,7 @@ use crate::{kcl, lookup_the_nearest_file_dir};
 use anyhow::{Result, bail};
 use kcl_config::modfile::KCL_MOD_FILE;
 use kcl_parser::LoadProgramOptions;
-use kcl_utils::pkgpath::{pkgpath_to_rel_path_buf, rm_external_pkg_name};
+use kcl_utils::pkgpath::external_pkgpath_to_rel_path_buf;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
 use std::{collections::HashMap, path::PathBuf, process::Command};
@@ -219,7 +219,6 @@ pub fn get_real_path_from_external(
         .unwrap_or_else(|_| PathBuf::new());
     real_path = real_path.join(pkg_root);
 
-    let pkgpath = rm_external_pkg_name(pkgpath).unwrap_or_default();
-    real_path.push(pkgpath_to_rel_path_buf(&pkgpath));
+    real_path.push(external_pkgpath_to_rel_path_buf(pkgpath));
     real_path
 }

--- a/crates/tools/src/LSP/src/completion.rs
+++ b/crates/tools/src/LSP/src/completion.rs
@@ -24,7 +24,7 @@ use kcl_driver::toolchain::{Metadata, Toolchain, get_real_path_from_external};
 use kcl_error::diagnostic::Range;
 use kcl_primitives::{DefaultHashBuilder, IndexMap, IndexSet};
 use kcl_sema::core::global_state::GlobalState;
-use kcl_utils::pkgpath::{pkgpath_to_rel_path_buf, rm_external_pkg_name};
+use kcl_utils::pkgpath::external_pkgpath_to_rel_path_buf;
 use std::io;
 use std::path::PathBuf;
 use std::{fs, path::Path};
@@ -787,8 +787,7 @@ fn dot_completion_in_import_stmt(
 /// `pkg_name`, so the caller can fall back to querying the toolchain.
 fn external_pkg_real_path(metadata: &Metadata, pkg_name: &str, pkgpath: &str) -> Option<PathBuf> {
     let mut real_path = metadata.packages.get(pkg_name)?.manifest_path.clone();
-    let sub_path = rm_external_pkg_name(pkgpath).unwrap_or_default();
-    real_path.push(pkgpath_to_rel_path_buf(&sub_path));
+    real_path.push(external_pkgpath_to_rel_path_buf(pkgpath));
     Some(real_path)
 }
 

--- a/crates/tools/src/LSP/src/completion.rs
+++ b/crates/tools/src/LSP/src/completion.rs
@@ -24,7 +24,7 @@ use kcl_driver::toolchain::{Metadata, Toolchain, get_real_path_from_external};
 use kcl_error::diagnostic::Range;
 use kcl_primitives::{DefaultHashBuilder, IndexMap, IndexSet};
 use kcl_sema::core::global_state::GlobalState;
-use kcl_utils::pkgpath::rm_external_pkg_name;
+use kcl_utils::pkgpath::{pkgpath_to_rel_path_buf, rm_external_pkg_name};
 use std::io;
 use std::path::PathBuf;
 use std::{fs, path::Path};
@@ -788,7 +788,7 @@ fn dot_completion_in_import_stmt(
 fn external_pkg_real_path(metadata: &Metadata, pkg_name: &str, pkgpath: &str) -> Option<PathBuf> {
     let mut real_path = metadata.packages.get(pkg_name)?.manifest_path.clone();
     let sub_path = rm_external_pkg_name(pkgpath).unwrap_or_default();
-    sub_path.split('.').for_each(|s| real_path.push(s));
+    real_path.push(pkgpath_to_rel_path_buf(&sub_path));
     Some(real_path)
 }
 

--- a/crates/tools/src/bundle/mod.rs
+++ b/crates/tools/src/bundle/mod.rs
@@ -15,6 +15,7 @@
 //! the main package are printed.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
@@ -23,6 +24,7 @@ use kcl_ast::walker::MutSelfMutWalker;
 use kcl_ast_pretty::print_ast_module;
 use kcl_config::vfs::fix_import_path;
 use kcl_parser::{LoadProgramOptions, ParseSession, load_program};
+use kcl_utils::pkgpath::pkgpath_to_path_buf;
 #[cfg(test)]
 mod tests;
 
@@ -252,22 +254,15 @@ fn import_target(root: &str, file: &str, rawpath: &str) -> Option<String> {
     if target.is_empty() {
         return None;
     }
-    let segments: Vec<&str> = target.split('.').collect();
-    let mut dir = std::path::PathBuf::from(root);
-    for segment in &segments {
-        dir.push(segment);
-    }
+    let dir = pkgpath_to_path_buf(Path::new(root), &target);
     if dir.is_dir() {
         return Some(target);
     }
-    if segments.len() > 1 {
-        let mut module = std::path::PathBuf::from(root);
-        for segment in &segments[..segments.len() - 1] {
-            module.push(segment);
-        }
-        module.push(format!("{}.k", segments[segments.len() - 1]));
+    if let Some((parent_pkgpath, last_segment)) = target.rsplit_once('.') {
+        let mut module = pkgpath_to_path_buf(Path::new(root), parent_pkgpath);
+        module.push(format!("{last_segment}.k"));
         if module.is_file() {
-            return Some(segments[..segments.len() - 1].join("."));
+            return Some(parent_pkgpath.to_string());
         }
     }
     Some(target)

--- a/crates/utils/src/pkgpath.rs
+++ b/crates/utils/src/pkgpath.rs
@@ -56,6 +56,18 @@ pub fn pkgpath_to_path_buf(root: &Path, pkgpath: &str) -> PathBuf {
     path
 }
 
+/// Strip the external package name prefix from a dotted pkgpath (e.g.
+/// `my_pkg.sub.dir` → `sub.dir`) and convert the remainder to a relative
+/// filesystem path with the platform-correct separator (e.g. `sub/dir`).
+///
+/// Empty input yields an empty path. Callers should pass valid external
+/// pkgpaths (no leading dot) and can push the package's manifest root on
+/// top to get a full filesystem path.
+pub fn external_pkgpath_to_rel_path_buf(pkgpath: &str) -> PathBuf {
+    let sub_path = rm_external_pkg_name(pkgpath).unwrap_or_default();
+    pkgpath_to_rel_path_buf(&sub_path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -100,6 +112,29 @@ mod tests {
         assert_eq!(
             pkgpath_to_path_buf(Path::new(abs), "a.b"),
             Path::new(abs).join(["a", "b"].join(sep))
+        );
+    }
+
+    #[test]
+    fn test_external_pkgpath_to_rel_path_buf() {
+        let sep = MAIN_SEPARATOR_STR;
+        // External prefix is stripped; remaining dotted segments become
+        // a relative path using the platform separator.
+        assert_eq!(
+            external_pkgpath_to_rel_path_buf("my_pkg.sub.dir"),
+            PathBuf::from(["sub", "dir"].join(sep))
+        );
+        // Bare external name (no dotted suffix) yields an empty path.
+        assert_eq!(external_pkgpath_to_rel_path_buf("my_pkg"), PathBuf::new());
+        // Empty input also yields an empty path.
+        assert_eq!(external_pkgpath_to_rel_path_buf(""), PathBuf::new());
+        // A leading dot yields an empty first segment that
+        // `parse_external_pkg_name` returns as Ok(""), so the strip is a
+        // no-op and the rest of the dotted path is joined normally.
+        // Callers should not pass non-external inputs.
+        assert_eq!(
+            external_pkgpath_to_rel_path_buf(".local.path"),
+            PathBuf::from(["local", "path"].join(sep))
         );
     }
 }

--- a/docs/design/pkgpath_type.md
+++ b/docs/design/pkgpath_type.md
@@ -1,0 +1,247 @@
+# PkgPath: typed boundary for compiler-side path unification
+
+| Status | Draft (architecture track, incremental) |
+| --- | --- |
+| Related | #966, #2178, PR #2179 |
+| Author | follow-up to zong-zhe's 2024 WIP design ([comment](https://github.com/kcl-lang/kcl/issues/966#issuecomment-1987663960)) and Peefy's 2026 status note |
+
+## Summary
+
+Introduce a `PkgPath` newtype around the dotted pkgpath string (`a.b.c`)
+so that the conversion to and from `PathBuf` lives in exactly one place.
+All internal compiler code carries `PkgPath`; only the boundary layers
+(parser entry, toolchain, LSP `didOpen`/`didChange` handlers, bundle
+rewriter) deal with raw `PathBuf` / `&str`. The goal is to make the class
+of Windows-only failures we've fixed repeatedly — hardcoded `/`
+separators, mismatched `ends_with("/...")` / `trim_end_matches("/...")`
+suffixes, dropped `let pkgpath = ` match bindings — impossible to write in
+the first place.
+
+This is the incremental shape of the VFS work that issue #966 proposed
+in 2024. The full `VFS` trait + `SourceFile` rewrite in zong-zhe's
+original design is **explicitly deferred** to a separate document; this
+doc covers the typed-key step that all later work can build on.
+
+## Status
+
+Done in #2178 and PR #2179:
+
+- 5 sites that hardcoded `/` between pkgpath segments now use
+  `pkgpath_to_rel_path_buf` / `pkgpath_to_path_buf`.
+- `get_pkg_list` no longer drops the `let pkgpath = match pkgpath.chars().next()`
+  binding that turns `./...` into a cwd-anchored walk and `a.b.c` into a
+  real directory path.
+- LSP `external_pkg_real_path` and driver `get_real_path_from_external`
+  both go through a single `external_pkgpath_to_rel_path_buf` helper.
+- `test_get_pkg_list` actually verifies the binding fix (used to only
+  assert on `.len()`).
+
+Open after this PR:
+
+- Sites still take `&str` and `PathBuf` interchangeably. A `PkgPath`
+  newtype would let the type system catch a regression instead of a test.
+- The full VFS abstraction from the 2024 design remains on the shelf.
+
+## Why now
+
+The compiler-side work shipped so far has been a sequence of targeted
+fixes against concrete failures. Each fix was correct in isolation, but
+the underlying problem is structural: pkgpath (a `String`) and
+filesystem path (a `PathBuf`) flow through the same call sites and the
+caller has to remember which is which and how to convert. Helper
+functions help, but they don't stop the next contributor from writing
+`Path::new(root).join(pkgpath.replace('.', "/"))` again — there's
+nothing in the type system to catch it.
+
+A `PkgPath` newtype is the smallest change that closes the gap. It
+doesn't replace the filesystem layer, doesn't change the public API,
+and doesn't break any golden file. It just makes the conversion
+monomorphic: you can have a `PkgPath` (in-memory) or a `PathBuf` (on
+disk) and converting between them is one `From` impl.
+
+## Non-goals
+
+- **Full VFS rewrite.** The 2024 WIP `VFS` trait, the `rustc::SourceFile`
+  wrapper, and the loader/Salsa/VFS split described in zong-zhe's
+  comment are out of scope. They require an architectural decision the
+  maintainer explicitly deferred in 2026.
+- **Per-crate path conversion helpers.** `pkgpath_to_path_buf` and
+  friends are not going away; the newtype is layered on top of them.
+- **Bundle / LSP URI display normalization.** `crates/tools/src/testing/
+  mod.rs::normalize_coverage_key` and the LSP `find_refs` /
+  `goto_def` `replace("\\", "/")` calls are OS-path-to-display
+  normalization, not pkgpath conversion. Different problem; leave alone.
+- **Changing the grammar or the public `kcl` CLI.** Internal-only.
+
+## Proposed design
+
+### The type
+
+```rust
+// crates/utils/src/pkgpath.rs (already hosts the conversion helpers)
+
+/// A dotted pkgpath (e.g. `a.b.c`), the compiler's canonical in-memory
+/// key for a package or module.
+///
+/// Use `PkgPath::to_path(&root)` to resolve to a filesystem path. Use
+/// `PkgPath::parse(&str)` to parse user input (relative imports,
+/// `kcl.mod` entries, CLI `-O key=value` arguments).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PkgPath {
+    pkgpath: String,
+}
+
+impl PkgPath {
+    pub fn new(pkgpath: impl Into<String>) -> Self { ... }
+    pub fn as_str(&self) -> &str { &self.pkgpath }
+    pub fn is_absolute(&self) -> bool { !self.pkgpath.starts_with('.') }
+
+    /// Resolve to an absolute filesystem path under `root` using the
+    /// platform-correct separator. This is the single place where the
+    /// `.` → `/` (or `\`) mapping lives.
+    pub fn to_path(&self, root: &Path) -> PathBuf {
+        pkgpath_to_path_buf(root, &self.pkgpath)
+    }
+
+    /// Parse user input (CLI arg, `kcl.mod` entry, relative import). The
+    /// parser already has `fix_import_path` in `crates/config/src/vfs.rs`;
+    /// wrapping it here gives every caller the same error reporting.
+    pub fn parse(import_path: &str, root: &str, file: &str) -> Option<Self> {
+        let pkgpath = kcl_config::vfs::fix_import_path(root, file, import_path);
+        if pkgpath.is_empty() { None } else { Some(Self::new(pkgpath)) }
+    }
+}
+
+impl From<&str> for PkgPath { ... }   // infallible; wraps
+impl From<String> for PkgPath { ... }
+```
+
+### Where it lives
+
+`crates/utils/src/pkgpath.rs` already hosts `pkgpath_to_path_buf`,
+`pkgpath_to_rel_path_buf`, `rm_external_pkg_name`, and
+`external_pkgpath_to_rel_path_buf`. `PkgPath` is the typed wrapper that
+composes them. `kcl-utils` is the lowest layer that both `kcl-config`
+(for `fix_import_path`) and `kcl-parser` / `kcl-sema` / `kcl-loader`
+already depend on, so adding the type here doesn't introduce a new
+crate dependency.
+
+### Where it gets used
+
+The conversion is structural — call sites get the type, not just the
+helper. Concretely, in this order of priority:
+
+1. **`fix_import_path` return value** (`crates/config/src/vfs.rs`).
+   Today it returns `String`. Change it to return `Option<PkgPath>`
+   (returning `None` for the "exceeds parent" case the function already
+   signals by `""`). One-line signature change; all current callers
+   (`kcl-loader`, `kcl-parser`, `kcl-sema`, `crates/tools/src/bundle`)
+   get the type and the `to_path` method, so they stop calling
+   `replace('.', "/")` on their own.
+
+2. **`Metadata.packages: HashMap<String, Package>`** in
+   `crates/driver/src/toolchain.rs`. The map key is a package name; the
+   value's `manifest_path` is a `PathBuf`. The dotted pkgpath form of
+   the import — `import my_pkg.sub.dir` — is computed by callers via
+   `external_pkgpath_to_rel_path_buf`. After this RFC the dotted side is
+   a `PkgPath` and the conversion to a `PathBuf` is `pkgpath.to_path(&manifest_path)`.
+   The cache (`crates/config/src/cache.rs::get_pkg_realpath_from_pkgpath`)
+   benefits automatically.
+
+3. **`CompileUnitOptions` and the loader result types.** They are
+   `(Vec<String>, Option<LoadProgramOptions>, Option<Metadata>)` today.
+   Leaving the outer shape alone but converting the file list and
+   `package_maps` keys to `Vec<PkgPath>` / `HashMap<PkgPath, _>` is the
+   incremental migration; it forces every caller to go through
+   `to_path` to get a `PathBuf`, which is the whole point.
+
+4. **Toolchain inputs.** `Toolchain::fetch_metadata(PathBuf)` and
+   `Toolchain::update_dependencies(PathBuf)` already take a `PathBuf`
+   for the manifest directory — that's a filesystem path, not a
+   pkgpath, so it stays as `PathBuf`. The PkgPath work is orthogonal
+   here.
+
+### Out of scope but informed by this design
+
+- **Toolchain inputs to package manifests.** Once `Metadata.packages`
+   has `PkgPath` keys, `get_real_path_from_external(tool, pkg_name:
+   &PkgPath, ...)` becomes type-safe. (Same for the LSP
+   `external_pkg_real_path`.)
+- **Loader ↔ evaluator handoff.** The evaluator currently takes
+  pkgpath strings in its schema/symbol tables. Migrating those is a
+  separate, larger change; the typed boundary this doc proposes is a
+  prerequisite but not the whole thing.
+- **A real `VFS` trait.** When (if) someone picks up zong-zhe's 2024
+  design, the `PkgPath` type from this doc is what the trait's
+  `exists(pkgpath: PkgPath) -> bool` signature should take. Building the
+  trait on top of the newtype means the newtype is the only thing that
+  changes later.
+
+## Migration plan
+
+Each step is independently shippable behind the existing test suite.
+
+1. **Land `PkgPath` in `kcl-utils`.** Add the type and `to_path`. Add
+   unit tests. No call-site changes. (Same shape as `pkgpath_to_path_buf`
+   landing in #2178.)
+
+2. **Convert `fix_import_path` return.** Update its callers in
+   `kcl-loader`, `kcl-parser`, `kcl-sema`, `crates/tools/src/bundle`,
+   and `crates/driver/src/toolchain`. Each is a one-line signature
+   change; the `String` they get today is just wrapped in
+   `PkgPath::new` for free.
+
+3. **Convert `Metadata.packages` map keys.** (Optional but cheap.)
+   Forces the remaining `replace('.', "/")` / `pkgpath_to_*_path_buf`
+   call sites in `driver::get_real_path_from_external` and
+   `LSP::external_pkg_real_path` to go through the newtype.
+
+4. **Convert `CompileUnitOptions` file list and `package_maps`.** This
+   is the load-bearing change — every parser/sema/runner entry point
+   flows through these, and the conversion to `PathBuf` happens at the
+   boundary with the filesystem.
+
+After step 4, no internal site should be able to write
+`pkgpath.replace('.', "/")` without first calling
+`pkgpath.to_path(&root)` and getting a `PathBuf`. The compiler's type
+system enforces the design.
+
+## Open questions
+
+1. **Should `PkgPath` reject empty strings at construction?** Today
+   `String` is accepted everywhere; a non-empty invariant would catch
+   some bugs. Cost: a `Result`-returning constructor or a panic. Lean
+   toward `Option` for the `parse` constructor and infallible `new`
+   for internal callers that already validated.
+
+2. **Do we need a separate `RelPkgPath` (always starts with `.`) and
+   `AbsPkgPath` (never does)?** The current `fix_import_path` returns
+   either depending on the input. A split would catch misuses earlier
+   but doubles the API surface. Defer until there's a concrete
+   caller that needs to enforce the distinction.
+
+3. **What about pkgpaths that map to a single file (`a.b.c` →
+   `a/b/c.k`)?** This is the bundle / `import_target` case. The
+   `to_path` method should probably take an `Option<&str>` extension
+   (default `"k"`) or expose a `to_file_path(root, &k)` companion.
+   The 2024 `PkgPath::new_with_extension` sketch covered this; we can
+   add it in step 1 of the migration if bundle work is in flight.
+
+4. **Does this conflict with the LSP salsa/VFS layer?** No. The
+   LSP-layer VFS holds `SourceFile` instances keyed by URI; `PkgPath`
+   lives below the parser boundary. They don't see each other. The
+   maintainer's 2026 status note already separates these as item 7
+   (LSP) and "compiler-side path unification" (this doc).
+
+## Alternatives considered
+
+- **Status quo + more helpers.** Keeps landing fixes as bugs appear.
+  Cost: every new caller is a new chance to get the conversion wrong;
+  test coverage is per-call-site, not structural.
+- **Adopt zong-zhe's 2024 design wholesale.** Right answer long-term,
+  wrong answer now: it requires a `SourceMap`-shaped refactor across
+  `kcl-parser`, `kcl-loader`, and the LSP layer that the maintainer
+  explicitly deferred in 2026.
+- **A new `vfs` crate.** Same as adopting the full design, minus the
+  `SourceFile` wrapper. Still requires per-crate API changes that
+  block on the maintainer's architectural decision.


### PR DESCRIPTION
## Summary

Follow-up to #2178 — closes out the remaining compiler-side path-unification work in issue #966 and adds a design doc for the next step.

Compiler-side changes (4 commits on top of #2178):

- **`crates/driver/src/lib.rs`**: `get_pkg_list` lost the `let pkgpath = ` binding on its `match pkgpath.chars().next()` block in early history. Without it, the cwd-join for relative inputs and the dotted-pkgpath → filesystem-path conversion were computed and thrown away, so callers like the test loader received the raw input string (e.g. `./...`, `a.b.c`) instead of the resolved directory. Restore the binding so `./...` walks resolve under cwd and dotted pkgpaths resolve to their on-disk directory.
- **`crates/tools/src/LSP/src/completion.rs`**: replace the hand-written `split('.').for_each(|s| path.push(s))` in `external_pkg_real_path` with the shared `pkgpath_to_rel_path_buf` helper, mirroring the same dedupe applied to `driver::get_real_path_from_external` in #2178. LSP-specific URI/VFS code paths are intentionally left alone.
- **`crates/utils/src/pkgpath.rs`**: add `external_pkgpath_to_rel_path_buf`, a one-call wrapper around the `rm_external_pkg_name` + `pkgpath_to_rel_path_buf` combo that previously lived inline in both `driver::toolchain::get_real_path_from_external` and `tools/LSP::external_pkg_real_path`. Behaviour is identical to the previous two-line implementation on every existing call site; the helper just gives one canonical definition plus a unit test for each interesting input. Apply it in both call sites.
- **`crates/driver/src/tests.rs`**: harden `test_get_pkg_list` so the binding fix above is actually exercised. The old test only asserted on `len()` and would still pass if the discarded match regressed; the new test asserts every returned entry is an absolute path that canonicalises to a real on-disk directory. Apply rustfmt so the format check passes.
- **`crates/tools/src/bundle/mod.rs`**: dedupe `import_target`'s two `split('.').collect()` + `for segment in segments { dir.push(segment) }` loops into single `pkgpath_to_path_buf` calls, using `rsplit_once('.')` for the parent/last-segment split. Same pattern as the five sites fixed in #2178 — `kcl bundle` was the only caller left in the compiler path that still had the hand-written form.

Design doc (1 commit):

- **`docs/design/pkgpath_type.md`**: PkgPath newtype RFC. Records the next architecture step beyond helper-function dedupe: a typed wrapper around the dotted pkgpath so the conversion to `PathBuf` lives in exactly one place and the type system catches the regression class instead of tests. References zong-zhe's 2024 WIP VFS design and the maintainer's 2026 status note that explicitly deferred the full VFS rewrite in favour of compiler-side path unification. This doc is the typed-boundary piece of that incremental track. Migration plan: land type → convert `fix_import_path` return → convert `Metadata.packages` keys → convert `CompileUnitOptions` file list / `package_maps`. Each step is independently shippable behind the existing test suite.

## Behavior change (intentional)

`get_pkg_list` for inputs that go through the missing match binding now returns resolved directory paths:
- `./src/test_data/pkg_list` → `<cwd>/src/test_data/pkg_list` (absolute) instead of `./src/test_data/pkg_list` (relative)
- `a.b.c` → `a/b/c` instead of `a.b.c`

No golden file in the grammar suite references the affected outputs.

## Out of scope

- Full VFS abstraction (the original scope of #966) — covered in the new RFC, deferred to a separate implementation track.
- OS-path-to-display normalization (coverage keys, LSP URIs) — different problem.

## Test plan

- [x] `cargo test -p kcl-utils` (5 tests, incl. new `external_pkgpath_to_rel_path_buf`)
- [x] `cargo test -p kcl-driver` (incl. hardened `test_get_pkg_list` covering both `./` and `./...`)
- [x] `cargo test -p kcl-tools` (69 unit + 4 doc + 2 bundle)
- [x] `cargo test -p kcl-parser -p kcl-sema -p kcl-config`
- [x] `cargo clippy --workspace --tests` — no new warnings
- [x] `cargo fmt --check` — clean
- [ ] Full platform CI matrix (Windows MSVC + MinGW, linux ×3, macOS ×3, WASM WASI)

Part of #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)